### PR TITLE
[FEAT] 케이크 전체 조회 API 구현

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/ApiResponse.java
+++ b/src/main/java/com/sopterm/makeawish/common/ApiResponse.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record ApiResponse(int status, boolean success, String message, Object data) {
+public record ApiResponse(boolean success, String message, Object data) {
 
 	public static ApiResponse success(String message, Object data) {
 		return ApiResponse.builder()
@@ -26,22 +26,5 @@ public record ApiResponse(int status, boolean success, String message, Object da
 			.success(false)
 			.message(message)
 			.build();
-	}
-
-	public static ApiResponse of(int status, boolean success, String message, Object data) {
-		return ApiResponse.builder()
-				.status(status)
-				.success(success)
-				.message(message)
-				.data(data)
-				.build();
-	}
-
-	public static ApiResponse of(int status, boolean success, String message) {
-		return ApiResponse.builder()
-				.status(status)
-				.success(success)
-				.message(message)
-				.build();
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -7,6 +7,10 @@ import lombok.Getter;
 @Getter
 public enum SuccessMessage {
 
+	// auth
+	SUCCESS_SIGN_IN("소셜 로그인 성공"),
+	SUCCESS_GET_REFRESH_TOKEN("토큰 재발급 성공"),
+
 	// cake
 	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공");
 

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -1,0 +1,14 @@
+package com.sopterm.makeawish.common.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum SuccessMessage {
+
+	// cake
+	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공");
+
+	private final String message;
+}

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     ) {
         AuthSignInResponseDto responseDto = authService.signIn(requestDto, clientId);
         ApiResponse apiResponse = ApiResponse.success(SUCCESS_SIGN_IN.getMessage(), responseDto);
-        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
+        return ResponseEntity.ok(apiResponse);
     }
 
     @PostMapping("/token")
@@ -38,6 +38,6 @@ public class AuthController {
         Long userId = Long.valueOf(principal.getName());
         AuthGetTokenResponseDto responseDto =  authService.getToken(userId);
         ApiResponse apiResponse = ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), responseDto);
-        return new ResponseEntity<>(apiResponse, HttpStatus.OK);
+        return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -9,7 +9,6 @@ import com.sopterm.makeawish.dto.auth.AuthSignInResponseDto;
 import com.sopterm.makeawish.service.AuthService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.sopterm.makeawish.controller;
 
+import static com.sopterm.makeawish.common.message.SuccessMessage.*;
+
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.dto.auth.AuthGetTokenResponseDto;
 import com.sopterm.makeawish.dto.auth.AuthSignInRequestDto;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+
 @Tag(name = "Auth", description = "인증")
 @RestController
 @RequiredArgsConstructor
@@ -25,9 +28,7 @@ public class AuthController {
             @RequestBody AuthSignInRequestDto requestDto
     ) {
         AuthSignInResponseDto responseDto = authService.signIn(requestDto, clientId);
-        ApiResponse apiResponse = ApiResponse.of(
-                HttpStatus.OK.value(), true, "소셜 로그인성공", responseDto
-        );
+        ApiResponse apiResponse = ApiResponse.success(SUCCESS_SIGN_IN.getMessage(), responseDto);
         return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 
@@ -36,8 +37,7 @@ public class AuthController {
     {
         Long userId = Long.valueOf(principal.getName());
         AuthGetTokenResponseDto responseDto =  authService.getToken(userId);
-        ApiResponse apiResponse = ApiResponse.of(
-                HttpStatus.OK.value(), true, "토큰 재발급 성공", responseDto);
+        ApiResponse apiResponse = ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), responseDto);
         return new ResponseEntity<>(apiResponse, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -1,0 +1,30 @@
+package com.sopterm.makeawish.controller;
+
+import static com.sopterm.makeawish.common.message.SuccessMessage.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
+import com.sopterm.makeawish.service.CakeService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/cakes")
+public class CakeController {
+
+	private final CakeService cakeService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse> getAllCakes() {
+		List<CakeResponseDTO> response = cakeService.getAllCakes();
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
+	}
+}

--- a/src/main/java/com/sopterm/makeawish/domain/Cake.java
+++ b/src/main/java/com/sopterm/makeawish/domain/Cake.java
@@ -6,8 +6,10 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Cake {
 
 	@Id @GeneratedValue(strategy = IDENTITY)

--- a/src/main/java/com/sopterm/makeawish/domain/user/User.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/User.java
@@ -53,7 +53,7 @@ public class User implements UserDetails {
 
     private String phoneNumber;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "wisher")
     private List<Wish> wishes = new ArrayList<>();
 
     @Override

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
@@ -1,0 +1,21 @@
+package com.sopterm.makeawish.dto.cake;
+
+import static lombok.AccessLevel.*;
+
+import com.sopterm.makeawish.domain.Cake;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record CakeResponseDTO(Long cakeId, String name, String imageUrl, int price) {
+
+	public static CakeResponseDTO from(Cake cake) {
+		return CakeResponseDTO.builder()
+			.cakeId(cake.getId())
+			.name(cake.getName())
+			.imageUrl(cake.getImageUrl())
+			.price(cake.getPrice())
+			.build();
+	}
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
@@ -4,7 +4,6 @@ import static lombok.AccessLevel.*;
 
 import com.sopterm.makeawish.domain.Cake;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 
 @Builder(access = PRIVATE)

--- a/src/main/java/com/sopterm/makeawish/repository/CakeRepository.java
+++ b/src/main/java/com/sopterm/makeawish/repository/CakeRepository.java
@@ -1,0 +1,8 @@
+package com.sopterm.makeawish.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.sopterm.makeawish.domain.Cake;
+
+public interface CakeRepository extends JpaRepository<Cake, Long> {
+}

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -1,0 +1,23 @@
+package com.sopterm.makeawish.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
+import com.sopterm.makeawish.repository.CakeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CakeService {
+
+	private final CakeRepository cakeRepository;
+
+	public List<CakeResponseDTO> getAllCakes() {
+		return cakeRepository.findAll()
+			.stream().map(CakeResponseDTO::from)
+			.toList();
+	}
+}


### PR DESCRIPTION
```
- commit message가 적절한지 확인해주세요.
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 가능한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제 부탁드립니다.
```

## ✨ 관련 이슈
closed #8 

## ✨ 변경 사항 및 이유
케이크 전체 조회 기능 구현

## ✨ PR Point
- User Entity에서 mappedBy = user 부분을 wisher로 변경했습니다. : Wisher Entity에서 User를 wisher 칼럼명으로 가지고 있음.
- AuthController: ApiResponse.of 를 사용하던 부분을 ApiResponse.success 로 통일했어요! (ResponseEntity 자체에서 상태 코드를 내려주기 때문에 ApiResponse에서 status 칼럼은 제거했습니다 :))

<br/>

**변경 전을 선호한다면 편하게 말해주세요!! 함께 맞춰나가보아용 ~.~**