### PR TITLE
[FEAT] 카카오결제 준비 API 구현

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/KakaoPayProperties.java
+++ b/src/main/java/com/sopterm/makeawish/common/KakaoPayProperties.java
@@ -1,0 +1,20 @@
+package com.sopterm.makeawish.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoPayProperties {
+    public static String adminKey;
+    public static String cid;
+
+    @Value("${kakaopay.admin-key}")
+    public void setAdminKey(String adminKey){
+        KakaoPayProperties.adminKey=adminKey;
+    }
+
+    @Value("${kakaopay.cid}")
+    public void setCid(String cid){
+        KakaoPayProperties.cid=cid;
+    }
+}

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -15,7 +15,8 @@ public enum SuccessMessage {
 	SUCCESS_CREATE_WISH("소원 링크 생성 성공"),
 
 	/** cake **/
-	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공");
+	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공"),
+	SUCCESS_GET_READY_KAKAOPAY("카카오페이 결제 준비 성공");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -4,10 +4,10 @@ import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 
 import java.util.List;
 
+import com.sopterm.makeawish.dto.cake.CakeReadyRequestDto;
+import com.sopterm.makeawish.dto.cake.CakeReadyResponseDto;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
@@ -26,5 +26,11 @@ public class CakeController {
 	public ResponseEntity<ApiResponse> getAllCakes() {
 		List<CakeResponseDTO> response = cakeService.getAllCakes();
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
+	}
+
+	@PostMapping("/ready")
+	public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request){
+		CakeReadyResponseDto response=cakeService.getKakaoPayReady(request);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -28,7 +28,7 @@ public class CakeController {
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
 	}
 
-	@PostMapping("/ready")
+	@PostMapping("/pay/ready")
 	public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request){
 		CakeReadyResponseDto response=cakeService.getKakaoPayReady(request);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
@@ -1,0 +1,17 @@
+package com.sopterm.makeawish.dto.cake;
+
+import lombok.Builder;
+
+@Builder
+public record CakeReadyRequestDto(
+        String partner_order_id,
+        String partner_user_id,
+        String item_name,
+        String total_amount,
+        String tax_free_amount,
+        String approval_url,
+        String cancel_url,
+        String fail_url
+) {
+
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
@@ -9,6 +9,7 @@ public record CakeReadyRequestDto(
         String item_name,
         String total_amount,
         String tax_free_amount,
+        String vat_amount,
         String approval_url,
         String cancel_url,
         String fail_url

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyResponseDto.java
@@ -1,0 +1,13 @@
+package com.sopterm.makeawish.dto.cake;
+
+import lombok.Builder;
+
+@Builder
+public record CakeReadyResponseDto(
+        String tid,
+        String next_redirect_app_url,
+        String next_redirect_mobile_url,
+        String next_redirect_pc_url,
+        String create_at
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyResponseDto.java
@@ -8,6 +8,6 @@ public record CakeReadyResponseDto(
         String next_redirect_app_url,
         String next_redirect_mobile_url,
         String next_redirect_pc_url,
-        String create_at
+        String created_at
 ) {
 }

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -2,12 +2,21 @@ package com.sopterm.makeawish.service;
 
 import java.util.List;
 
+import com.sopterm.makeawish.common.KakaoPayProperties;
+import com.sopterm.makeawish.dto.cake.CakeReadyRequestDto;
+import com.sopterm.makeawish.dto.cake.CakeReadyResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
 import com.sopterm.makeawish.repository.CakeRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +24,47 @@ public class CakeService {
 
 	private final CakeRepository cakeRepository;
 
+
 	public List<CakeResponseDTO> getAllCakes() {
 		return cakeRepository.findAll()
 			.stream().map(CakeResponseDTO::from)
 			.toList();
+	}
+
+
+	public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request){ // 결제 요청
+		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
+		parameters.add("cid", KakaoPayProperties.cid);
+		parameters.add("partner_order_id", request.partner_order_id());
+		parameters.add("partner_user_id", request.partner_user_id());
+		parameters.add("item_name",request.item_name());
+		parameters.add("quantity", "1");
+		parameters.add("total_amount", request.total_amount());
+		parameters.add("vat_amount", request.vat_amount());
+		parameters.add("tax_free_amount", request.tax_free_amount());
+		parameters.add("approval_url", request.approval_url());
+		parameters.add("cancel_url", request.cancel_url());
+		parameters.add("fail_url", request.fail_url());
+
+		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(parameters, this.getHeaders());
+
+		RestTemplate restTemplate=new RestTemplate();
+
+		CakeReadyResponseDto response=restTemplate.postForObject(
+				"https://kapi.kakao.com/v1/payment/ready",
+				requestEntity,
+				CakeReadyResponseDto.class
+		);
+		return response;
+	}
+
+	private HttpHeaders getHeaders(){
+		HttpHeaders httpHeaders=new HttpHeaders();
+		String auth="KakaoAK "+KakaoPayProperties.adminKey;
+
+		httpHeaders.set("Authorization", auth);
+		httpHeaders.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+		return httpHeaders;
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import com.sopterm.makeawish.common.KakaoPayProperties;
 import com.sopterm.makeawish.dto.cake.CakeReadyRequestDto;
 import com.sopterm.makeawish.dto.cake.CakeReadyResponseDto;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -24,29 +23,14 @@ public class CakeService {
 
 	private final CakeRepository cakeRepository;
 
-
 	public List<CakeResponseDTO> getAllCakes() {
 		return cakeRepository.findAll()
 			.stream().map(CakeResponseDTO::from)
 			.toList();
 	}
 
-
 	public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request){ // 결제 요청
-		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
-		parameters.add("cid", KakaoPayProperties.cid);
-		parameters.add("partner_order_id", request.partner_order_id());
-		parameters.add("partner_user_id", request.partner_user_id());
-		parameters.add("item_name",request.item_name());
-		parameters.add("quantity", "1");
-		parameters.add("total_amount", request.total_amount());
-		parameters.add("vat_amount", request.vat_amount());
-		parameters.add("tax_free_amount", request.tax_free_amount());
-		parameters.add("approval_url", request.approval_url());
-		parameters.add("cancel_url", request.cancel_url());
-		parameters.add("fail_url", request.fail_url());
-
-		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(parameters, this.getHeaders());
+		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getParameters(request), this.getHeaders());
 
 		RestTemplate restTemplate=new RestTemplate();
 
@@ -66,5 +50,22 @@ public class CakeService {
 		httpHeaders.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
 		return httpHeaders;
+	}
+
+	private MultiValueMap<String, String> getParameters(CakeReadyRequestDto request){
+		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
+		parameters.add("cid", KakaoPayProperties.cid);
+		parameters.add("partner_order_id", request.partner_order_id());
+		parameters.add("partner_user_id", request.partner_user_id());
+		parameters.add("item_name",request.item_name());
+		parameters.add("quantity", "1");
+		parameters.add("total_amount", request.total_amount());
+		parameters.add("vat_amount", request.vat_amount());
+		parameters.add("tax_free_amount", request.tax_free_amount());
+		parameters.add("approval_url", request.approval_url());
+		parameters.add("cancel_url", request.cancel_url());
+		parameters.add("fail_url", request.fail_url());
+
+		return parameters;
 	}
 }


### PR DESCRIPTION

## ✨ 관련 이슈
closed #15 

## ✨ 변경 사항 및 이유
* 카카오페이 준비를 설정하였습니다.
* 준비에 필요한 값들을 모두 request로 설정하였는데 클라 개발자분이랑 상의한 후에 수정하겠습니다!
* 또한 response로 app, mobile, pc url을 보내주는데 이 부분도 상의한 후에 수정하겠습니다! 


## ✨ PR Point
* 카카오페이 준비에 필요한 비밀값(`admin-key`, `cid`)을 `application-dev.yml`에 넣어  `KakaoPayProperties`파일을 이용해 사용하였습니다.