### PR TITLE
[FEAT] 메인 화면 조회 API 구현

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -14,6 +14,8 @@ public enum SuccessMessage {
 	/** wish **/
 	SUCCESS_CREATE_WISH("소원 링크 생성 성공"),
 	SUCCESS_FIND_WISH("소원 링크 조회 성공"),
+	NO_WISH("진행 중인 소원이 없습니다."),
+	SUCCESS_GET_MAIN_WISH("진행 중인 소원 조회 성공"),
 
 	/** cake **/
 	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공");

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -3,6 +3,7 @@ package com.sopterm.makeawish.controller;
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.*;
+import static org.springframework.http.HttpStatus.*;
 
 import java.net.URI;
 import java.security.Principal;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.dto.wish.MainWishResponseDTO;
 import com.sopterm.makeawish.dto.wish.WishRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishResponseDTO;
 import com.sopterm.makeawish.service.WishService;
@@ -42,6 +44,14 @@ public class WishController {
 	public ResponseEntity<ApiResponse> findWish(@PathVariable Long wishId) {
 		WishResponseDTO response = wishService.findWish(wishId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_FIND_WISH.getMessage(), response));
+	}
+
+	@GetMapping("/main")
+	public ResponseEntity<ApiResponse> findMainWish(Principal principal) {
+		MainWishResponseDTO response = wishService.findMainWish(getUserId(principal));
+		return nonNull(response)
+			? ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_MAIN_WISH.getMessage(), response))
+			: ResponseEntity.status(NO_CONTENT).body(ApiResponse.success(NO_WISH.getMessage()));
 	}
 
 	private Long getUserId(Principal principal) {

--- a/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
@@ -1,0 +1,50 @@
+package com.sopterm.makeawish.dto.wish;
+
+import static com.sopterm.makeawish.common.message.ErrorMessage.*;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import com.sopterm.makeawish.domain.wish.Wish;
+
+import lombok.Builder;
+
+@Builder
+public record MainWishResponseDTO(Long wishId, String name, int cakeCount, long dayCount, int price,
+								  int percent, String imageUrl) {
+
+	public static MainWishResponseDTO from(Wish wish) {
+		int calculatedPercent = getPercent(wish.getPresentPrice(), wish.getTotalPrice());
+		return MainWishResponseDTO.builder()
+			.wishId(wish.getId())
+			.name(wish.getWisher().getAccount().getName())
+			.cakeCount(wish.getPresents().size())
+			.dayCount(getRemainDay(wish.getEndAt()))
+			.price(wish.getTotalPrice())
+			.percent(calculatedPercent)
+			.imageUrl(getImageUrl(calculatedPercent))
+			.build();
+	}
+
+	private static String getImageUrl(int percent) {
+		if (percent < 0) {
+			return "case1";
+		} else if (percent == 0) {
+			return "case2";
+		} else {
+			return "case3";
+		}
+	}
+
+	private static int getPercent(int presentPrice, int totalPrice) {
+		return (totalPrice / presentPrice) * 100;
+	}
+
+	private static long getRemainDay(LocalDateTime endAt) {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isAfter(endAt)) {
+			throw new IllegalArgumentException(EXPIRE_WISH.getMessage());
+		}
+		return ChronoUnit.DAYS.between(now, endAt);
+	}
+}

--- a/src/main/java/com/sopterm/makeawish/dto/wish/WishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/WishResponseDTO.java
@@ -2,21 +2,15 @@ package com.sopterm.makeawish.dto.wish;
 
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 
-import java.sql.Date;
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
-import java.time.ZoneId;
-import java.util.TimeZone;
+import java.time.temporal.ChronoUnit;
 
-import com.sopterm.makeawish.common.message.ErrorMessage;
 import com.sopterm.makeawish.domain.wish.Wish;
 
 import lombok.Builder;
 
 @Builder
-public record WishResponseDTO(String name, int dayCount, String title, String hint) {
+public record WishResponseDTO(String name, long dayCount, String title, String hint) {
 
 	public static WishResponseDTO from(Wish wish) {
 		return WishResponseDTO.builder()
@@ -27,12 +21,11 @@ public record WishResponseDTO(String name, int dayCount, String title, String hi
 			.build();
 	}
 
-	private static int getRemainDay(LocalDateTime date) {
-		LocalDate now = LocalDate.now((ZoneId.of("Asia/Seoul")));
-		LocalDate endDate = LocalDate.from(date);
-		if (now.isAfter(endDate)) {
+	private static long getRemainDay(LocalDateTime endAt) {
+		LocalDateTime now = LocalDateTime.now();
+		if (now.isAfter(endAt)) {
 			throw new IllegalArgumentException(EXPIRE_WISH.getMessage());
 		}
-		return Period.between(now, endDate).getDays();
+		return ChronoUnit.DAYS.between(now, endAt);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/repository/WishRepository.java
+++ b/src/main/java/com/sopterm/makeawish/repository/WishRepository.java
@@ -1,8 +1,16 @@
 package com.sopterm.makeawish.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.domain.wish.Wish;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
+
+	@Query("select w from Wish w where w.wisher = :wisher and w.startAt <= :now and w.endAt >= :now")
+	Optional<Wish> findMainWish(User wisher, LocalDateTime now);
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -1,12 +1,16 @@
 package com.sopterm.makeawish.service;
 
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
+import static java.util.Objects.*;
+
+import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.dto.wish.MainWishResponseDTO;
 import com.sopterm.makeawish.dto.wish.WishRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishResponseDTO;
 import com.sopterm.makeawish.repository.UserRepository;
@@ -31,6 +35,13 @@ public class WishService {
 
 	public WishResponseDTO findWish(Long wishId) {
 		return WishResponseDTO.from(getWish(wishId));
+	}
+
+	public MainWishResponseDTO findMainWish(Long userId) {
+		Wish wish = wishRepository
+			.findMainWish(getUser(userId), LocalDateTime.now())
+			.orElse(null);
+		return nonNull(wish) ? MainWishResponseDTO.from(wish) : null;
 	}
 
 	private Wish getWish(Long id) {


### PR DESCRIPTION
## ✨ 관련 이슈
closed #14 

## ✨ 변경 사항 및 이유
- 메인 화면 조회 API 구현
- 남은 일수 계산식 수정

## ✨ PR Point
- 남은 일수 계산식 수정: 링크 조회에서 계산 오류가 있어서 수정했습니다.
- 메인 케이크 이미지: 솝텀 후 단계 기능이어서 이미지 url을 우선 "case1" ~ "case3"으로 대체했습니다.

