### PR TITLE
[FEAT] 카카오페이 결제 승인 + 저장 API 구현

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/KakaoPayProperties.java
+++ b/src/main/java/com/sopterm/makeawish/common/KakaoPayProperties.java
@@ -7,14 +7,26 @@ import org.springframework.stereotype.Component;
 public class KakaoPayProperties {
     public static String adminKey;
     public static String cid;
+    public static String readyUrl;
+    public static String approveUrl;
 
     @Value("${kakaopay.admin-key}")
-    public void setAdminKey(String adminKey){
-        KakaoPayProperties.adminKey=adminKey;
+    public void setAdminKey(String adminKey) {
+        KakaoPayProperties.adminKey = adminKey;
     }
 
     @Value("${kakaopay.cid}")
-    public void setCid(String cid){
-        KakaoPayProperties.cid=cid;
+    public void setCid(String cid) {
+        KakaoPayProperties.cid = cid;
+    }
+
+    @Value("${kakaopay.ready-url}")
+    public void setReadyUrl(String readyUrl) {
+        KakaoPayProperties.readyUrl = readyUrl;
+    }
+
+    @Value("${kakaopay.approve-url}")
+    public void setApproveUrl(String approveUrl) {
+        KakaoPayProperties.approveUrl = approveUrl;
     }
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -10,7 +10,8 @@ public enum ErrorMessage {
 	INVALID_WISH("존재하지 않는 소원 링크입니다."),
 	EXIST_MAIN_WISH("이미 진행 중인 소원 링크가 있습니다."),
 	INVALID_USER("인증되지 않은 회원입니다."),
-	NULL_PRINCIPAL("principal 이 null 일 수 없습니다.");
+	NULL_PRINCIPAL("principal 이 null 일 수 없습니다."),
+	INVALID_CAKE("존재하지 않는 케이크입니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -17,7 +17,8 @@ public enum SuccessMessage {
 
 	/** cake **/
 	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공"),
-	SUCCESS_GET_READY_KAKAOPAY("카카오페이 결제 준비 성공");
-
+	SUCCESS_GET_READY_KAKAOPAY("카카오페이 결제 준비 성공"),
+	SUCCESS_CREATE_CAKE("케이크 저장 성공"),
+	SUCCESS_GET_PGTOKEN("pg 토큰 전달 성공");
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -1,21 +1,19 @@
 package com.sopterm.makeawish.controller;
 
-import java.util.List;
-
-import static com.sopterm.makeawish.common.message.SuccessMessage.*;
-
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.domain.Cake;
 import com.sopterm.makeawish.domain.wish.Wish;
 import com.sopterm.makeawish.dto.cake.*;
 import com.sopterm.makeawish.service.CakeService;
 import com.sopterm.makeawish.service.WishService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,18 +24,6 @@ public class CakeController {
     private final WishService wishService;
 
     @Operation(description = "케이크 리스트 조회")
-    @GetMapping
-    public ResponseEntity<ApiResponse> getAllCakes() {
-      List<CakeResponseDTO> response = cakeService.getAllCakes();
-      return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
-    }
-
-    @PostMapping("/pay/ready")
-    public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request){
-      CakeReadyResponseDto response=cakeService.getKakaoPayReady(request);
-      return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));
-    }
-
     @GetMapping
     public ResponseEntity<ApiResponse> getAllCakes() {
         List<CakeResponseDTO> response = cakeService.getAllCakes();

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -1,36 +1,53 @@
 package com.sopterm.makeawish.controller;
 
-import static com.sopterm.makeawish.common.message.SuccessMessage.*;
-
-import java.util.List;
-
-import com.sopterm.makeawish.dto.cake.CakeReadyRequestDto;
-import com.sopterm.makeawish.dto.cake.CakeReadyResponseDto;
+import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.domain.Cake;
+import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.dto.cake.*;
+import com.sopterm.makeawish.service.CakeService;
+import com.sopterm.makeawish.service.WishService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.sopterm.makeawish.common.ApiResponse;
-import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
-import com.sopterm.makeawish.service.CakeService;
+import java.util.List;
 
-import lombok.RequiredArgsConstructor;
+import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_ALL_CAKE;
+import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_READY_KAKAOPAY;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/cakes")
 public class CakeController {
 
-	private final CakeService cakeService;
+    private final CakeService cakeService;
+    private final WishService wishService;
 
-	@GetMapping
-	public ResponseEntity<ApiResponse> getAllCakes() {
-		List<CakeResponseDTO> response = cakeService.getAllCakes();
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
-	}
+    @GetMapping
+    public ResponseEntity<ApiResponse> getAllCakes() {
+        List<CakeResponseDTO> response = cakeService.getAllCakes();
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
+    }
 
-	@PostMapping("/pay/ready")
-	public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request){
-		CakeReadyResponseDto response=cakeService.getKakaoPayReady(request);
-		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));
-	}
+    @PostMapping("/pay/ready")
+    public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request) {
+        CakeReadyResponseDto response = cakeService.getKakaoPayReady(request);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));
+    }
+
+    @PostMapping("/pay/approve")
+    public ResponseEntity<ApiResponse> createCake(@RequestBody CakeApproveRequestDto request) {
+        Cake cake = cakeService.findById(request.cake());
+        if (cake.getId() != 1) {
+            CakeApproveResponseDto response = cakeService.getKakaoPayApprove(request);
+        }
+        Wish wish = wishService.getWish(request.wishId());
+        CakeCreateResponseDto response= cakeService.createPresent(request.name(), cake, wish, request.message());
+        return ResponseEntity.ok(ApiResponse.success("편지 저장 성공", response));
+    }
+
+    @GetMapping("/pay/approve")
+    public String getPgToken(@RequestParam String pg_token) {
+        return pg_token;
+    }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -41,12 +41,12 @@ public class CakeController {
             CakeApproveResponseDto response = cakeService.getKakaoPayApprove(request);
         }
         Wish wish = wishService.getWish(request.wishId());
-        CakeCreateResponseDto response= cakeService.createPresent(request.name(), cake, wish, request.message());
+        CakeCreateResponseDto response = cakeService.createPresent(request.name(), cake, wish, request.message());
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_CREATE_CAKE.getMessage(), response));
     }
 
     @GetMapping("/pay/approve")
-    public ResponseEntity<ApiResponse> getPgToken(@RequestParam String pg_token) {
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), pg_token));
+    public ResponseEntity<ApiResponse> getPgToken(@RequestParam("pg_token") String pgToken) {
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), pgToken));
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -12,8 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_ALL_CAKE;
-import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_READY_KAKAOPAY;
+import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,11 +42,11 @@ public class CakeController {
         }
         Wish wish = wishService.getWish(request.wishId());
         CakeCreateResponseDto response= cakeService.createPresent(request.name(), cake, wish, request.message());
-        return ResponseEntity.ok(ApiResponse.success("편지 저장 성공", response));
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_CREATE_CAKE.getMessage(), response));
     }
 
     @GetMapping("/pay/approve")
     public ResponseEntity<ApiResponse> getPgToken(@RequestParam String pg_token) {
-        return ResponseEntity.ok(ApiResponse.success("pg 토큰 전달", pg_token));
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), pg_token));
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -47,7 +47,7 @@ public class CakeController {
     }
 
     @GetMapping("/pay/approve")
-    public String getPgToken(@RequestParam String pg_token) {
-        return pg_token;
+    public ResponseEntity<ApiResponse> getPgToken(@RequestParam String pg_token) {
+        return ResponseEntity.ok(ApiResponse.success("pg 토큰 전달", pg_token));
     }
 }

--- a/src/main/java/com/sopterm/makeawish/domain/Present.java
+++ b/src/main/java/com/sopterm/makeawish/domain/Present.java
@@ -12,8 +12,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
 @NoArgsConstructor
 public class Present {

--- a/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
+++ b/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
@@ -1,91 +1,84 @@
 package com.sopterm.makeawish.domain.wish;
 
-import static jakarta.persistence.FetchType.*;
-import static jakarta.persistence.GenerationType.*;
-import static java.util.Objects.*;
+import com.sopterm.makeawish.domain.Present;
+import com.sopterm.makeawish.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.sopterm.makeawish.domain.Present;
-import com.sopterm.makeawish.domain.user.User;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.util.Objects.nonNull;
 
 @Entity
 @Getter
 @NoArgsConstructor
 public class Wish {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	@Column(name = "wish_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "wish_id")
+    private Long id;
 
-	private String title;
+    private String title;
 
-	private String presentImageUrl;
+    private String presentImageUrl;
 
-	@Column(columnDefinition = "TEXT")
-	private String hint1;
+    @Column(columnDefinition = "TEXT")
+    private String hint1;
 
-	private String hint2;
+    private String hint2;
 
-	private LocalDateTime startAt;
+    private LocalDateTime startAt;
 
-	private LocalDateTime endAt;
+    private LocalDateTime endAt;
 
-	@Embedded
-	private AccountInfo account;
+    @Embedded
+    private AccountInfo account;
 
-	private String phoneNumber;
+    private String phoneNumber;
 
-	private int presentPrice;
+    private int presentPrice;
 
-	private int totalPrice;
+    private int totalPrice;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "user_id")
-	private User wisher;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id")
+    private User wisher;
 
-	@OneToMany(mappedBy = "wish")
-	private final List<Present> presents = new ArrayList<>();
+    @OneToMany(mappedBy = "wish")
+    private final List<Present> presents = new ArrayList<>();
 
-	@Builder
-	public Wish(String title, String presentImageUrl, String hint1, String hint2, LocalDateTime startAt,
-		LocalDateTime endAt, AccountInfo account, String phoneNumber, int presentPrice, User wisher) {
-		this.title = title;
-		this.presentImageUrl = presentImageUrl;
-		this.hint1 = hint1;
-		this.hint2 = hint2;
-		this.startAt = startAt;
-		this.endAt = endAt;
-		this.account = account;
-		this.phoneNumber = phoneNumber;
-		this.presentPrice = presentPrice;
-		this.totalPrice = 0;
-		setUser(wisher);
-	}
+    @Builder
+    public Wish(String title, String presentImageUrl, String hint1, String hint2, LocalDateTime startAt,
+                LocalDateTime endAt, AccountInfo account, String phoneNumber, int presentPrice, User wisher) {
+        this.title = title;
+        this.presentImageUrl = presentImageUrl;
+        this.hint1 = hint1;
+        this.hint2 = hint2;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.account = account;
+        this.phoneNumber = phoneNumber;
+        this.presentPrice = presentPrice;
+        this.totalPrice = 0;
+        setUser(wisher);
+    }
 
-	private void setUser(User user) {
-		if (nonNull(this.wisher)) {
-			this.wisher.getWishes().remove(this);
-		}
-		this.wisher = user;
-		user.getWishes().add(this);
-	}
+    private void setUser(User user) {
+        if (nonNull(this.wisher)) {
+            this.wisher.getWishes().remove(this);
+        }
+        this.wisher = user;
+        user.getWishes().add(this);
+    }
 
-	public void updateTotalPrice(int price){
-		this.totalPrice+=price;
-	}
+    public void updateTotalPrice(int price) {
+        this.totalPrice += price;
+    }
 }

--- a/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
+++ b/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
@@ -84,4 +84,8 @@ public class Wish {
 		this.wisher = user;
 		user.getWishes().add(this);
 	}
+
+	public void updateTotalPrice(int price){
+		this.totalPrice+=price;
+	}
 }

--- a/src/main/java/com/sopterm/makeawish/dto/cake/Amount.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/Amount.java
@@ -1,0 +1,11 @@
+package com.sopterm.makeawish.dto.cake;
+
+public record Amount(
+        int total,
+        int tax_free,
+        int vat,
+        int point,
+        int discount,
+        int green_deposit
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
@@ -1,13 +1,18 @@
 package com.sopterm.makeawish.dto.cake;
 
+import com.sopterm.makeawish.domain.Cake;
+import lombok.Builder;
+
+@Builder
 public record CakeApproveRequestDto(
-        boolean isPaid,
         String pg_token,
         String tid,
         String partner_order_id,
         String partner_user_id,
         String name,
-        int cake,
-        String letter
+        String cake,
+        String price,
+        String message,
+        Long wishId
 ) {
 }

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
@@ -4,10 +4,10 @@ import lombok.Builder;
 
 @Builder
 public record CakeApproveRequestDto(
-        String pg_token,
+        String pgToken,
         String tid,
-        String partner_order_id,
-        String partner_user_id,
+        String partnerOrderId,
+        String partnerUserId,
         String name,
         Long cake,
         String message,

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
@@ -1,6 +1,5 @@
 package com.sopterm.makeawish.dto.cake;
 
-import com.sopterm.makeawish.domain.Cake;
 import lombok.Builder;
 
 @Builder
@@ -10,8 +9,7 @@ public record CakeApproveRequestDto(
         String partner_order_id,
         String partner_user_id,
         String name,
-        String cake,
-        String price,
+        Long cake,
         String message,
         Long wishId
 ) {

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveRequestDto.java
@@ -1,0 +1,13 @@
+package com.sopterm.makeawish.dto.cake;
+
+public record CakeApproveRequestDto(
+        boolean isPaid,
+        String pg_token,
+        String tid,
+        String partner_order_id,
+        String partner_user_id,
+        String name,
+        int cake,
+        String letter
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveResponseDto.java
@@ -1,0 +1,10 @@
+package com.sopterm.makeawish.dto.cake;
+
+public record CakeApproveResponseDto(
+        boolean isPaid,
+        String imageUrl,
+        int cakeType,
+        String contribute,
+        String wisher
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeApproveResponseDto.java
@@ -1,10 +1,20 @@
 package com.sopterm.makeawish.dto.cake;
 
 public record CakeApproveResponseDto(
-        boolean isPaid,
-        String imageUrl,
-        int cakeType,
-        String contribute,
-        String wisher
+    String aid,
+    String tid,
+    String cid,
+    String sid,
+    String partner_order_id,
+    String partner_user_id,
+    String payment_method_type,
+    String item_name,
+    String item_code,
+    int quantity,
+    Amount amount,
+    CardInfo cardInfo,
+    String created_at,
+    String approved_at,
+    String payload
 ) {
 }

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeCreateResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeCreateResponseDto.java
@@ -1,0 +1,14 @@
+package com.sopterm.makeawish.dto.cake;
+
+import lombok.Builder;
+
+@Builder
+public record CakeCreateResponseDto(
+        Long cake,
+        String imageUrl,
+        String hint1,
+        String hint2,
+        String contribute,
+        String wisher
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 public record CakeReadyRequestDto(
         String partner_order_id,
         String partner_user_id,
-        String item_name,
-        String total_amount,
+        Long cake,
         String tax_free_amount,
         String vat_amount,
         String approval_url,

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeReadyRequestDto.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 
 @Builder
 public record CakeReadyRequestDto(
-        String partner_order_id,
-        String partner_user_id,
+        String partnerOrderId,
+        String partnerUserId,
         Long cake,
-        String tax_free_amount,
-        String vat_amount,
-        String approval_url,
-        String cancel_url,
-        String fail_url
+        String taxFreeAmount,
+        String vatAmount,
+        String approvalUrl,
+        String cancelUrl,
+        String failUrl
 ) {
 
 }

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CardInfo.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CardInfo.java
@@ -1,0 +1,20 @@
+package com.sopterm.makeawish.dto.cake;
+
+public record CardInfo(
+        String purchase_corp,
+        String purchase_corp_code,
+        String issuer_corp,
+        String issuer_corp_code,
+        String kakaopay_purchase_corp,
+        String kakaopay_purchase_corp_code,
+        String kakaopay_issuer_corp,
+        String kakaopay_issuer_corp_code,
+        String bin,
+        String card_type,
+        String install_month,
+        String approved_id,
+        String card_mid,
+        String interest_free_install,
+        String card_item_code
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/repository/PresentRepository.java
+++ b/src/main/java/com/sopterm/makeawish/repository/PresentRepository.java
@@ -1,0 +1,7 @@
+package com.sopterm.makeawish.repository;
+
+import com.sopterm.makeawish.domain.Present;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PresentRepository extends JpaRepository<Present, Long> {
+}

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -1,120 +1,120 @@
 package com.sopterm.makeawish.service;
 
-import java.util.List;
-
 import com.sopterm.makeawish.common.KakaoPayProperties;
+import com.sopterm.makeawish.common.message.ErrorMessage.*;
 import com.sopterm.makeawish.domain.Cake;
 import com.sopterm.makeawish.domain.Present;
 import com.sopterm.makeawish.domain.wish.Wish;
 import com.sopterm.makeawish.dto.cake.*;
+import com.sopterm.makeawish.repository.CakeRepository;
 import com.sopterm.makeawish.repository.PresentRepository;
 import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
-
-import com.sopterm.makeawish.repository.CakeRepository;
-
-import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
+
+import static com.sopterm.makeawish.common.message.ErrorMessage.INVALID_CAKE;
+
 @Service
 @RequiredArgsConstructor
 public class CakeService {
 
-	private final CakeRepository cakeRepository;
-	private final PresentRepository presentRepository;
+    private final CakeRepository cakeRepository;
+    private final PresentRepository presentRepository;
 
-	public List<CakeResponseDTO> getAllCakes() {
-		return cakeRepository.findAll()
-			.stream().map(CakeResponseDTO::from)
-			.toList();
-	}
+    public List<CakeResponseDTO> getAllCakes() {
+        return cakeRepository.findAll()
+                .stream().map(CakeResponseDTO::from)
+                .toList();
+    }
 
-	public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request){ // 결제 요청
-		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getReadyParameters(request), this.getHeaders());
+    public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request) {
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(this.getReadyParameters(request), this.getHeaders());
 
-		RestTemplate restTemplate=new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+        CakeReadyResponseDto response = restTemplate.postForObject(
+                KakaoPayProperties.readyUrl,
+                requestEntity,
+                CakeReadyResponseDto.class
+        );
+        return response;
+    }
 
-		CakeReadyResponseDto response=restTemplate.postForObject(
-				"https://kapi.kakao.com/v1/payment/ready",
-				requestEntity,
-				CakeReadyResponseDto.class
-		);
-		return response;
-	}
+    private HttpHeaders getHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        String auth = "KakaoAK " + KakaoPayProperties.adminKey;
 
-	private HttpHeaders getHeaders(){
-		HttpHeaders httpHeaders=new HttpHeaders();
-		String auth="KakaoAK "+KakaoPayProperties.adminKey;
+        httpHeaders.set("Authorization", auth);
+        httpHeaders.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
-		httpHeaders.set("Authorization", auth);
-		httpHeaders.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        return httpHeaders;
+    }
 
-		return httpHeaders;
-	}
+    private MultiValueMap<String, String> getReadyParameters(CakeReadyRequestDto request) {
+        Cake cake = cakeRepository.findById(request.cake()).orElseThrow(EntityNotFoundException::new);
 
-	private MultiValueMap<String, String> getReadyParameters(CakeReadyRequestDto request){
-		Cake cake=cakeRepository.findById(request.cake()).orElseThrow(EntityNotFoundException::new);
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("cid", KakaoPayProperties.cid);
+        parameters.add("partner_order_id", request.partnerOrderId());
+        parameters.add("partner_user_id", request.partnerUserId());
+        parameters.add("item_name", cake.getName());
+        parameters.add("quantity", "1");
+        parameters.add("total_amount", String.valueOf(cake.getPrice()));
+        parameters.add("vat_amount", request.vatAmount());
+        parameters.add("tax_free_amount", request.taxFreeAmount());
+        parameters.add("approval_url", request.approvalUrl());
+        parameters.add("cancel_url", request.cancelUrl());
+        parameters.add("fail_url", request.failUrl());
 
-		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
-		parameters.add("cid", KakaoPayProperties.cid);
-		parameters.add("partner_order_id", request.partner_order_id());
-		parameters.add("partner_user_id", request.partner_user_id());
-		parameters.add("item_name", cake.getName());
-		parameters.add("quantity", "1");
-		parameters.add("total_amount", String.valueOf(cake.getPrice()));
-		parameters.add("vat_amount", request.vat_amount());
-		parameters.add("tax_free_amount", request.tax_free_amount());
-		parameters.add("approval_url", request.approval_url());
-		parameters.add("cancel_url", request.cancel_url());
-		parameters.add("fail_url", request.fail_url());
+        return parameters;
+    }
 
-		return parameters;
-	}
+    private MultiValueMap<String, String> getApproveParameters(CakeApproveRequestDto request) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("cid", KakaoPayProperties.cid);
+        parameters.add("partner_order_id", request.partnerOrderId());
+        parameters.add("partner_user_id", request.partnerUserId());
+        parameters.add("tid", request.tid());
+        parameters.add("pg_token", request.pgToken());
 
-	private MultiValueMap<String, String> getApproveParameters(CakeApproveRequestDto request){
-		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
-		parameters.add("cid", KakaoPayProperties.cid);
-		parameters.add("partner_order_id", request.partner_order_id());
-		parameters.add("partner_user_id", request.partner_user_id());
-		parameters.add("tid", request.tid());
-		parameters.add("pg_token", request.pg_token());
+        return parameters;
+    }
 
-		return parameters;
-	}
+    public CakeApproveResponseDto getKakaoPayApprove(CakeApproveRequestDto request) {
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(this.getApproveParameters(request), this.getHeaders());
 
-	public CakeApproveResponseDto getKakaoPayApprove(CakeApproveRequestDto request){
-		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getApproveParameters(request), this.getHeaders());
+        RestTemplate restTemplate = new RestTemplate();
 
-		RestTemplate restTemplate=new RestTemplate();
+        CakeApproveResponseDto response = restTemplate.postForObject(
+                KakaoPayProperties.approveUrl,
+                requestEntity,
+                CakeApproveResponseDto.class
+        );
+        return response;
+    }
 
-		CakeApproveResponseDto response=restTemplate.postForObject(
-				"https://kapi.kakao.com/v1/payment/approve",
-				requestEntity,
-				CakeApproveResponseDto.class
-		);
-		return response;
-	}
+    @Transactional
+    public CakeCreateResponseDto createPresent(String name, Cake cake, Wish wish, String message) {
+        Present present = new Present(name, message, wish, cake);
+        presentRepository.save(present);
+        wish.updateTotalPrice(cake.getPrice());
+        String contribute = calculateContribute(cake.getPrice(), wish.getPresentPrice());
+        CakeCreateResponseDto response = new CakeCreateResponseDto(cake.getId(), wish.getPresentImageUrl(), wish.getHint1(), wish.getHint2(), contribute, wish.getWisher().getAccount().getName());
+        return response;
+    }
 
-	@Transactional
-	public CakeCreateResponseDto createPresent(String name, Cake cake, Wish wish, String message){
-		Present present=new Present(name, message, wish, cake);
-		presentRepository.save(present);
-		wish.updateTotalPrice(cake.getPrice());
-		String contribute=calculateContribute(cake.getPrice(), wish.getPresentPrice());
-		CakeCreateResponseDto response= new CakeCreateResponseDto(cake.getId(), wish.getPresentImageUrl(),wish.getHint1(), wish.getHint2(), contribute, wish.getWisher().getAccount().getName());
-		return response;
-	}
+    private String calculateContribute(int price, int targetPrice) {
+        return String.format("%.0f", (double) price / (double) targetPrice * 100);
+    }
 
-	private String calculateContribute(int price, int targetPrice){
-		return String.format("%.0f", (double)price/ (double)targetPrice * 100);
-	}
-
-	public Cake findById(Long id){
-		return cakeRepository.findById(id).orElseThrow(EntityNotFoundException::new);
-	}
+    public Cake findById(Long id) {
+        return cakeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(INVALID_CAKE.getMessage()));
+    }
 }

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -3,16 +3,20 @@ package com.sopterm.makeawish.service;
 import java.util.List;
 
 import com.sopterm.makeawish.common.KakaoPayProperties;
-import com.sopterm.makeawish.dto.cake.CakeReadyRequestDto;
-import com.sopterm.makeawish.dto.cake.CakeReadyResponseDto;
+import com.sopterm.makeawish.domain.Cake;
+import com.sopterm.makeawish.domain.Present;
+import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.dto.cake.*;
+import com.sopterm.makeawish.repository.PresentRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
-import com.sopterm.makeawish.dto.cake.CakeResponseDTO;
 import com.sopterm.makeawish.repository.CakeRepository;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -22,6 +26,7 @@ import org.springframework.web.client.RestTemplate;
 public class CakeService {
 
 	private final CakeRepository cakeRepository;
+	private final PresentRepository presentRepository;
 
 	public List<CakeResponseDTO> getAllCakes() {
 		return cakeRepository.findAll()
@@ -30,7 +35,7 @@ public class CakeService {
 	}
 
 	public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request){ // 결제 요청
-		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getParameters(request), this.getHeaders());
+		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getReadyParameters(request), this.getHeaders());
 
 		RestTemplate restTemplate=new RestTemplate();
 
@@ -52,14 +57,16 @@ public class CakeService {
 		return httpHeaders;
 	}
 
-	private MultiValueMap<String, String> getParameters(CakeReadyRequestDto request){
+	private MultiValueMap<String, String> getReadyParameters(CakeReadyRequestDto request){
+		Cake cake=cakeRepository.findById(request.cake()).orElseThrow(EntityNotFoundException::new);
+
 		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
 		parameters.add("cid", KakaoPayProperties.cid);
 		parameters.add("partner_order_id", request.partner_order_id());
 		parameters.add("partner_user_id", request.partner_user_id());
-		parameters.add("item_name",request.item_name());
+		parameters.add("item_name", cake.getName());
 		parameters.add("quantity", "1");
-		parameters.add("total_amount", request.total_amount());
+		parameters.add("total_amount", String.valueOf(cake.getPrice()));
 		parameters.add("vat_amount", request.vat_amount());
 		parameters.add("tax_free_amount", request.tax_free_amount());
 		parameters.add("approval_url", request.approval_url());
@@ -67,5 +74,47 @@ public class CakeService {
 		parameters.add("fail_url", request.fail_url());
 
 		return parameters;
+	}
+
+	private MultiValueMap<String, String> getApproveParameters(CakeApproveRequestDto request){
+		MultiValueMap<String, String> parameters=new LinkedMultiValueMap<>();
+		parameters.add("cid", KakaoPayProperties.cid);
+		parameters.add("partner_order_id", request.partner_order_id());
+		parameters.add("partner_user_id", request.partner_user_id());
+		parameters.add("tid", request.tid());
+		parameters.add("pg_token", request.pg_token());
+
+		return parameters;
+	}
+
+	public CakeApproveResponseDto getKakaoPayApprove(CakeApproveRequestDto request){
+		HttpEntity<MultiValueMap<String, String>> requestEntity=new HttpEntity<>(this.getApproveParameters(request), this.getHeaders());
+
+		RestTemplate restTemplate=new RestTemplate();
+
+		CakeApproveResponseDto response=restTemplate.postForObject(
+				"https://kapi.kakao.com/v1/payment/approve",
+				requestEntity,
+				CakeApproveResponseDto.class
+		);
+		return response;
+	}
+
+	@Transactional
+	public CakeCreateResponseDto createPresent(String name, Cake cake, Wish wish, String message){
+		Present present=new Present(name, message, wish, cake);
+		presentRepository.save(present);
+		wish.updateTotalPrice(cake.getPrice());
+		String contribute=calculateContribute(cake.getPrice(), wish.getPresentPrice());
+		CakeCreateResponseDto response= new CakeCreateResponseDto(cake.getId(), wish.getPresentImageUrl(),wish.getHint1(), wish.getHint2(), contribute, wish.getWisher().getAccount().getName());
+		return response;
+	}
+
+	private String calculateContribute(int price, int targetPrice){
+		return String.format("%.0f", (double)price/ (double)targetPrice * 100);
+	}
+
+	public Cake findById(Long id){
+		return cakeRepository.findById(id).orElseThrow(EntityNotFoundException::new);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -39,7 +39,7 @@ public class WishService {
 		return WishResponseDTO.from(getWish(wishId));
 	}
 
-	private Wish getWish(Long id) {
+	public Wish getWish(Long id) {
 		return wishRepository.findById(id)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_WISH.getMessage()));
 	}


### PR DESCRIPTION
## ✨ 관련 이슈
closed #18 

## ✨ 변경 사항 및 이유
결제 승인과 저장을 구현하였습니다.
0원 케이크인 경우엔 저장을, 나머지 케이크에 대해서는 승인과 저장을 하게 했습니다.  
테스트 해볼 때 pg_token값이 필요해서 `@GetMapping("/pay/approve)`를 설정하였는데 필요가 없다면 후에 삭제하도록 하겠습니다! 

## ✨ PR Point
고치면 좋을 부분 알려주시면 좋겠습니다!! ~ 감사합니다 ~ ~
