### PR TITLE
[FEAT] 소원 결과 상세 조회

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -11,7 +11,8 @@ public enum ErrorMessage {
 	EXIST_MAIN_WISH("이미 진행 중인 소원 링크가 있습니다."),
 	INVALID_USER("인증되지 않은 회원입니다."),
 	NULL_PRINCIPAL("principal 이 null 일 수 없습니다."),
-	INVALID_CAKE("존재하지 않는 케이크입니다.");
+	INVALID_CAKE("존재하지 않는 케이크입니다."),
+	INCORRECT_WISH("본인의 소원 링크가 아닙니다");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -21,6 +21,7 @@ public enum SuccessMessage {
 	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공"),
 	SUCCESS_GET_READY_KAKAOPAY("카카오페이 결제 준비 성공"),
 	SUCCESS_CREATE_CAKE("케이크 저장 성공"),
-	SUCCESS_GET_PGTOKEN("pg 토큰 전달 성공");
+	SUCCESS_GET_PGTOKEN("pg 토큰 전달 성공"),
+	SUCCESS_GET_ALL_PRESENT("선물 전체 조회 성공");
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -29,7 +31,12 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         try {
             String accessToken = getJwtFromRequest(request);
             String uri = request.getRequestURI();
-            if(uri.startsWith("/api/v1/auth") || uri.startsWith("/api/v1/cakes") || uri.startsWith("/v3/api-docs") ||
+
+            if(uri.equals("/api/v1/cakes")){
+                filterChain.doFilter(request, response);
+                return;
+            }
+            if(uri.startsWith("/api/v1/auth") || (uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST)) || uri.startsWith("/v3/api-docs") ||
                 uri.startsWith("/swagger-ui") || uri.startsWith("/api/v1/wishes") || uri.startsWith("/health")) {
                 filterChain.doFilter(request, response);
                 return;

--- a/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
@@ -31,7 +31,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         try {
             String accessToken = getJwtFromRequest(request);
             String uri = request.getRequestURI();
-            if(uri.startsWith("/api/v1/auth") ||  uri.equals("/api/v1/cakes") && request.getMethod().equals(HttpMethod.GET) || uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST)) || uri.startsWith("/v3/api-docs") ||
+            if(uri.startsWith("/api/v1/auth") ||  uri.equals("/api/v1/cakes") && request.getMethod().equals(HttpMethod.GET) || uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST) || uri.startsWith("/v3/api-docs") ||
                 uri.startsWith("/swagger-ui") || (uri.startsWith("/api/v1/wishes") && request.getMethod().equals("GET")) || uri.startsWith("/health")) {
                 filterChain.doFilter(request, response);
                 return;

--- a/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
@@ -36,7 +36,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
-            if(uri.startsWith("/api/v1/auth") || (uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST)) || uri.startsWith("/v3/api-docs") ||
+            if(uri.startsWith("/api/v1/auth") || uri.equals("/api/v1/cakes") && request.getMethod().equals(HttpMethod.GET) ||(uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST)) || uri.startsWith("/v3/api-docs") ||
                 uri.startsWith("/swagger-ui") || uri.startsWith("/api/v1/wishes") || uri.startsWith("/health")) {
                 filterChain.doFilter(request, response);
                 return;

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.List;
 
+import static com.sopterm.makeawish.common.message.ErrorMessage.INCORRECT_WISH;
 import static com.sopterm.makeawish.common.message.ErrorMessage.NULL_PRINCIPAL;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.isNull;
@@ -60,10 +61,9 @@ public class CakeController {
     public ResponseEntity<ApiResponse> getPresents(Principal principal, @PathVariable("wishId") Long wishId) {
         Wish wish = wishService.getWish(wishId);
         Long userId = getUserId(principal);
-        if (!isRightWisher(userId, wish))
-            return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), ""));
+        isRightWisher(userId, wish);
         List<PresentDto> response = cakeService.getPresents(wish);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), response));
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
     }
 
     private Long getUserId(Principal principal) {
@@ -73,7 +73,8 @@ public class CakeController {
         return Long.valueOf(principal.getName());
     }
 
-    private boolean isRightWisher(Long userId, Wish wish) {
-        return userId.equals(wish.getWisher().getId());
+    private void isRightWisher(Long userId, Wish wish) {
+        if (!userId.equals(wish.getWisher().getId()))
+            throw new IllegalArgumentException(INCORRECT_WISH.getMessage());
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 import java.util.List;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.INCORRECT_WISH;
 import static com.sopterm.makeawish.common.message.ErrorMessage.NULL_PRINCIPAL;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.isNull;
@@ -59,25 +58,16 @@ public class CakeController {
 
     @GetMapping("/{wishId}")
     public ResponseEntity<ApiResponse> getPresents(Principal principal, @PathVariable("wishId") Long wishId) {
-        Wish wish = wishService.getWish(wishId);
         Long userId = getUserId(principal);
-        if (isRightWisher(userId, wish)) {
-            List<PresentDto> response = cakeService.getPresents(wish);
-            return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
-        }
-        throw new IllegalArgumentException(INCORRECT_WISH.getMessage());
+        List<PresentDto> response = cakeService.getPresents(userId, wishId);
+        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
     }
+
 
     private Long getUserId(Principal principal) {
         if (isNull(principal)) {
             throw new IllegalArgumentException(NULL_PRINCIPAL.getMessage());
         }
         return Long.valueOf(principal.getName());
-    }
-
-    private boolean isRightWisher(Long userId, Wish wish) {
-        if (!userId.equals(wish.getWisher().getId()))
-            return false;
-        return true;
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -61,9 +61,11 @@ public class CakeController {
     public ResponseEntity<ApiResponse> getPresents(Principal principal, @PathVariable("wishId") Long wishId) {
         Wish wish = wishService.getWish(wishId);
         Long userId = getUserId(principal);
-        isRightWisher(userId, wish);
-        List<PresentDto> response = cakeService.getPresents(wish);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
+        if (isRightWisher(userId, wish)) {
+            List<PresentDto> response = cakeService.getPresents(wish);
+            return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
+        }
+        throw new IllegalArgumentException(INCORRECT_WISH.getMessage());
     }
 
     private Long getUserId(Principal principal) {
@@ -73,8 +75,9 @@ public class CakeController {
         return Long.valueOf(principal.getName());
     }
 
-    private void isRightWisher(Long userId, Wish wish) {
+    private boolean isRightWisher(Long userId, Wish wish) {
         if (!userId.equals(wish.getWisher().getId()))
-            throw new IllegalArgumentException(INCORRECT_WISH.getMessage());
+            return false;
+        return true;
     }
 }

--- a/src/main/java/com/sopterm/makeawish/domain/Cake.java
+++ b/src/main/java/com/sopterm/makeawish/domain/Cake.java
@@ -1,24 +1,47 @@
 package com.sopterm.makeawish.domain;
 
-import static jakarta.persistence.GenerationType.*;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Cake {
 
-	@Id @GeneratedValue(strategy = IDENTITY)
-	@Column(name = "cake_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "cake_id")
+    private Long id;
 
-	private String name;
+    private String name;
 
-	private int price;
+    private int price;
 
-	private String imageUrl;
+    private String imageUrl;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        return ((Cake) o).getId().equals(getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/cake/CakeResponseDTO.java
@@ -17,4 +17,13 @@ public record CakeResponseDTO(Long cakeId, String name, String imageUrl, int pri
 			.price(cake.getPrice())
 			.build();
 	}
+
+	public Cake toEntity(){
+		return Cake.builder()
+				.id(cakeId)
+				.name(name)
+				.imageUrl(imageUrl)
+				.price(price)
+				.build();
+	}
 }

--- a/src/main/java/com/sopterm/makeawish/dto/present/PresentDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/present/PresentDto.java
@@ -1,0 +1,22 @@
+package com.sopterm.makeawish.dto.present;
+
+import com.sopterm.makeawish.domain.Cake;
+import com.sopterm.makeawish.domain.Present;
+import lombok.Builder;
+
+@Builder
+public record PresentDto(
+        Long cakeId,
+        String name,
+        String imageUrl,
+        Long count
+) {
+    public static PresentDto from(Cake cake, Long count){
+        return PresentDto.builder()
+                .cakeId(cake.getId())
+                .name(cake.getName())
+                .imageUrl(cake.getImageUrl())
+                .count(count)
+                .build();
+    }
+}

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -23,12 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.sopterm.makeawish.common.message.ErrorMessage.INCORRECT_WISH;
 import static com.sopterm.makeawish.common.message.ErrorMessage.INVALID_CAKE;
 
 @Service
 @RequiredArgsConstructor
 public class CakeService {
 
+    private final WishService wishService;
     private final CakeRepository cakeRepository;
     private final PresentRepository presentRepository;
 
@@ -121,28 +123,35 @@ public class CakeService {
         return cakeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(INVALID_CAKE.getMessage()));
     }
 
-    public List<PresentDto> getPresents(Wish wish) {
+    public List<PresentDto> getPresents(Long userId, Long wishId) {
+        Wish wish = wishService.getWish(wishId);
+        if (!isRightWisher(userId, wish))
+            throw new IllegalArgumentException(INCORRECT_WISH.getMessage());
+
         Map<Cake, Long> allCake = getAllCakes().stream()
                 .collect(Collectors.toMap(
                         CakeResponseDTO::toEntity,
                         count -> 0L));
 
         Map<Cake, Long> cakes = getAllPresent(wish);
-
         allCake.putAll(cakes);
 
         List<PresentDto> response = allCake.entrySet().stream()
                 .map(cake -> PresentDto.from(cake.getKey(), cake.getValue()))
                 .sorted(Comparator.comparing(PresentDto::cakeId))
                 .toList();
-
         return response;
     }
 
     private Map<Cake, Long> getAllPresent(Wish wish) {
         Map<Cake, Long> cakes = wish.getPresents().stream()
                 .collect(Collectors.groupingBy(Present::getCake, Collectors.counting()));
-
         return cakes;
+    }
+
+    private boolean isRightWisher(Long userId, Wish wish) {
+        if (!userId.equals(wish.getWisher().getId()))
+            return false;
+        return true;
     }
 }

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -127,8 +127,7 @@ public class CakeService {
                         CakeResponseDTO::toEntity,
                         count -> 0L));
 
-        Map<Cake, Long> cakes = wish.getPresents().stream()
-                .collect(Collectors.groupingBy(Present::getCake, Collectors.counting()));
+        Map<Cake, Long> cakes = getAllPresent(wish);
 
         allCake.putAll(cakes);
 
@@ -138,5 +137,12 @@ public class CakeService {
                 .toList();
 
         return response;
+    }
+
+    private Map<Cake, Long> getAllPresent(Wish wish) {
+        Map<Cake, Long> cakes = wish.getPresents().stream()
+                .collect(Collectors.groupingBy(Present::getCake, Collectors.counting()));
+
+        return cakes;
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈
closed #23 

## ✨ 변경 사항 및 이유
- 소원 링크에 대한 케이크 전체 결과를 가져왔습니다. (0개 포함)
- `wishId`를 갖지 않는 사용자일 경우를 위해 예외처리를 했습니다.

## ✨ PR Point
- `uri.startsWith(/api/v1/cakes)`로 하니까 토큰이 넘어가지 않아 토큰 검사를 하지 않는 `uri.equals(/api/v1/cakes)`로 따로 뺐습니다.
