### PR TITLE
[FIX] 결제 관련 수정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
+++ b/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import jakarta.persistence.EntityNotFoundException;
+import org.springframework.web.client.HttpClientErrorException;
 
 @RestControllerAdvice
 public class ErrorHandler {
@@ -18,6 +19,12 @@ public class ErrorHandler {
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResponse> handleIllegalArgumentExceptionException(IllegalArgumentException exception) {
+		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler(HttpClientErrorException.class)
+	public ResponseEntity<ApiResponse> handleHttpClientErrorExceptionException(HttpClientErrorException exception) {
 		ApiResponse response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}

--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -13,7 +13,8 @@ public enum ErrorMessage {
 	INVALID_USER("인증되지 않은 회원입니다."),
 	NULL_PRINCIPAL("principal 이 null 일 수 없습니다."),
 	INVALID_CAKE("존재하지 않는 케이크입니다."),
-	INCORRECT_WISH("본인의 소원 링크가 아닙니다");
+	INCORRECT_WISH("본인의 소원 링크가 아닙니다"),
+	NOT_PAID_CAKE("결제가 필요한 케이크가 아닙니다");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
@@ -31,8 +31,9 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         try {
             String accessToken = getJwtFromRequest(request);
             String uri = request.getRequestURI();
-            if(uri.startsWith("/api/v1/auth") ||  uri.equals("/api/v1/cakes") && request.getMethod().equals(HttpMethod.GET) || uri.startsWith("/api/v1/cakes") && request.getMethod().equals(HttpMethod.POST) || uri.startsWith("/v3/api-docs") ||
-                uri.startsWith("/swagger-ui") || (uri.startsWith("/api/v1/wishes") && request.getMethod().equals("GET")) || uri.startsWith("/health")) {
+            System.out.println("uri - " + uri);
+            if (uri.startsWith("/favicon.ico") || uri.startsWith("/api/v1/auth") || uri.equals("/api/v1/cakes") || uri.startsWith("/api/v1/cakes/pay") || uri.startsWith("/v3/api-docs") ||
+                    uri.startsWith("/swagger-ui") || (uri.startsWith("/api/v1/wishes") && request.getMethod().equals("GET")) || uri.startsWith("/health")) {
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/sopterm/makeawish/config/jwt/JwtTokenFilter.java
@@ -31,7 +31,6 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         try {
             String accessToken = getJwtFromRequest(request);
             String uri = request.getRequestURI();
-            System.out.println("uri - " + uri);
             if (uri.startsWith("/favicon.ico") || uri.startsWith("/api/v1/auth") || uri.equals("/api/v1/cakes") || uri.startsWith("/api/v1/cakes/pay") || uri.startsWith("/v3/api-docs") ||
                     uri.startsWith("/swagger-ui") || (uri.startsWith("/api/v1/wishes") && request.getMethod().equals("GET")) || uri.startsWith("/health")) {
                 filterChain.doFilter(request, response);

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -34,12 +34,14 @@ public class CakeController {
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_CAKE.getMessage(), response));
     }
 
+    @Operation(summary = "카카오페이 결제 준비")
     @PostMapping("/pay/ready")
     public ResponseEntity<ApiResponse> getKakaoPayReady(@RequestBody CakeReadyRequestDto request) {
         CakeReadyResponseDto response = cakeService.getKakaoPayReady(request);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_READY_KAKAOPAY.getMessage(), response));
     }
 
+    @Operation(summary = "카카오페이 결제 승인 및 선물 저장")
     @PostMapping("/pay/approve")
     public ResponseEntity<ApiResponse> createCake(@RequestBody CakeApproveRequestDto request) {
         Cake cake = cakeService.findById(request.cake());
@@ -51,11 +53,13 @@ public class CakeController {
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_CREATE_CAKE.getMessage(), response));
     }
 
+    @Operation(summary = "카카오페이 결제 준비 후 pg 토큰 발급")
     @GetMapping("/pay/approve")
     public ResponseEntity<ApiResponse> getPgToken(@RequestParam("pg_token") String pgToken) {
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PGTOKEN.getMessage(), pgToken));
     }
 
+    @Operation(summary = "해당 소원에 대한 케이크 결과 조회")
     @GetMapping("/{wishId}")
     public ResponseEntity<ApiResponse> getPresents(Principal principal, @PathVariable("wishId") Long wishId) {
         Long userId = getUserId(principal);

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Comparator;
@@ -41,14 +42,17 @@ public class CakeService {
 
     public CakeReadyResponseDto getKakaoPayReady(CakeReadyRequestDto request) {
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(this.getReadyParameters(request), this.getHeaders());
-
-        RestTemplate restTemplate = new RestTemplate();
-        CakeReadyResponseDto response = restTemplate.postForObject(
-                KakaoPayProperties.readyUrl,
-                requestEntity,
-                CakeReadyResponseDto.class
-        );
-        return response;
+        try {
+            RestTemplate restTemplate = new RestTemplate();
+            CakeReadyResponseDto response = restTemplate.postForObject(
+                    KakaoPayProperties.readyUrl,
+                    requestEntity,
+                    CakeReadyResponseDto.class
+            );
+            return response;
+        } catch (HttpClientErrorException e) {
+            throw new HttpClientErrorException(e.getStatusCode(), e.getStatusText());
+        }
     }
 
     private HttpHeaders getHeaders() {
@@ -95,13 +99,16 @@ public class CakeService {
         HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(this.getApproveParameters(request), this.getHeaders());
 
         RestTemplate restTemplate = new RestTemplate();
-
-        CakeApproveResponseDto response = restTemplate.postForObject(
-                KakaoPayProperties.approveUrl,
-                requestEntity,
-                CakeApproveResponseDto.class
-        );
-        return response;
+        try {
+            CakeApproveResponseDto response = restTemplate.postForObject(
+                    KakaoPayProperties.approveUrl,
+                    requestEntity,
+                    CakeApproveResponseDto.class
+            );
+            return response;
+        } catch (HttpClientErrorException e) {
+            throw new HttpClientErrorException(e.getStatusCode(), e.getStatusText());
+        }
     }
 
     @Transactional

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -51,7 +51,7 @@ public class CakeService {
             );
             return response;
         } catch (HttpClientErrorException e) {
-            throw new HttpClientErrorException(e.getStatusCode(), e.getStatusText());
+            throw new HttpClientErrorException(e.getStatusCode(), e.getMessage());
         }
     }
 
@@ -107,7 +107,7 @@ public class CakeService {
             );
             return response;
         } catch (HttpClientErrorException e) {
-            throw new HttpClientErrorException(e.getStatusCode(), e.getStatusText());
+            throw new HttpClientErrorException(e.getStatusCode(), e.getMessage());
         }
     }
 

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -23,8 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.INCORRECT_WISH;
-import static com.sopterm.makeawish.common.message.ErrorMessage.INVALID_CAKE;
+import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 
 @Service
 @RequiredArgsConstructor
@@ -63,7 +62,7 @@ public class CakeService {
     }
 
     private MultiValueMap<String, String> getReadyParameters(CakeReadyRequestDto request) {
-        Cake cake = cakeRepository.findById(request.cake()).orElseThrow(EntityNotFoundException::new);
+        Cake cake = getCake(request.cake());
 
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.add("cid", KakaoPayProperties.cid);
@@ -153,5 +152,13 @@ public class CakeService {
         if (!userId.equals(wish.getWisher().getId()))
             return false;
         return true;
+    }
+
+    public Cake getCake(Long cakeId) {
+        if (cakeId.equals(1L)) {
+            throw new IllegalArgumentException(NOT_PAID_CAKE.getMessage());
+        }
+        Cake cake = findById(cakeId);
+        return cake;
     }
 }


### PR DESCRIPTION

## ✨ 관련 이슈
closed #31 

## ✨ 변경 사항 및 이유
- 카카오페이 준비 시 무료 케이크가 들어올 때 에러 처리
- 통신 전용 error handler 적용 

## ✨ PR Point
- 카카오페이 준비할 때 무료 케이크가 결제 화면으로 넘어가지 않도록 에러처리를 수정하였습니다.
- 통신할 때 나오는 에러를 `ErrorHandler`에 추가하였습니다.
- 토큰 검사에서 에러가 나지 않도록 경로를 수정하였습니다.
- 고민은 `e.getMessage`를 하면 주게 되는 message 내용이 `400 Bad Request: \"{\"msg\":\"payment is already done!\",\"code\":-702}\""` 이렇게 되어서 해당 `msg` 내용만 깔끔하게 줄 지 고민입니다.,..
