### PR TITLE
[CHORE] Refresh토큰 발급 로직 추가 및 토큰 로직변경에 따른 유저 조회 방법 수정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/config/SecurityConfig.java
+++ b/src/main/java/com/sopterm/makeawish/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .and()
                     .authorizeHttpRequests()
                     .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html", "/health",
-                            "/api/v1/auth/**", "/api/v1/present/**").permitAll()
+                            "/api/v1/auth/**", "/api/v1/presents/**").permitAll()
                 .and()
                     .authorizeHttpRequests()
                     .requestMatchers("/api/v1/cakes/**", "/api/v1/wishes/**", "/api/v1/user/**").hasAuthority("MEMBER")

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -43,7 +43,6 @@ public class AuthController {
     @PostMapping("/token")
     public ResponseEntity<ApiResponse> getToken(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails)
     {
-        System.out.println(memberDetails.getId());
         AuthGetTokenResponseDto responseDto =  authService.getToken(memberDetails.getId());
         ApiResponse apiResponse = ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), responseDto);
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -2,17 +2,22 @@ package com.sopterm.makeawish.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.domain.user.InternalMemberDetails;
+import com.sopterm.makeawish.dto.auth.AuthGetTokenResponseDto;
 import com.sopterm.makeawish.dto.auth.AuthSignInResponseDto;
 import com.sopterm.makeawish.service.AuthService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_REFRESH_TOKEN;
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_SIGN_IN;
 
 @RestController
@@ -31,6 +36,16 @@ public class AuthController {
     public ResponseEntity<ApiResponse> signIn(@RequestParam String code) throws JsonProcessingException {
         AuthSignInResponseDto responseDto = authService.socialLogin("KAKAO", code);
         ApiResponse apiResponse = ApiResponse.success(SUCCESS_SIGN_IN.getMessage(), responseDto);
+        return ResponseEntity.ok(apiResponse);
+    }
+
+    @Operation(summary = "AccessToken 재발급")
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse> getToken(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails)
+    {
+        System.out.println(memberDetails.getId());
+        AuthGetTokenResponseDto responseDto =  authService.getToken(memberDetails.getId());
+        ApiResponse apiResponse = ApiResponse.success(SUCCESS_GET_REFRESH_TOKEN.getMessage(), responseDto);
         return ResponseEntity.ok(apiResponse);
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -15,10 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_SIGN_IN;
 
-@Tag(name = "Auth", description = "인증")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "인증")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/sopterm/makeawish/controller/CakeController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/CakeController.java
@@ -1,53 +1,47 @@
 package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.domain.user.InternalMemberDetails;
 import com.sopterm.makeawish.dto.present.PresentDto;
 import com.sopterm.makeawish.dto.present.PresentResponseDto;
 import com.sopterm.makeawish.service.CakeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.security.Principal;
 import java.util.List;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.NULL_PRINCIPAL;
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_ALL_PRESENT;
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_PRESENT_MESSAGE;
-import static java.util.Objects.isNull;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/cakes")
+@SecurityRequirement(name = "Authorization")
 public class CakeController {
 
     private final CakeService cakeService;
 
     @Operation(summary = "해당 소원에 대한 케이크 결과 조회")
     @GetMapping("/{wishId}")
-    public ResponseEntity<ApiResponse> getPresents(Principal principal, @PathVariable("wishId") Long wishId) {
-        Long userId = getUserId(principal);
-        List<PresentDto> response = cakeService.getPresents(userId, wishId);
+    public ResponseEntity<ApiResponse> getPresents(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+                                                   @PathVariable("wishId") Long wishId) {
+        List<PresentDto> response = cakeService.getPresents(memberDetails.getId(), wishId);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_ALL_PRESENT.getMessage(), response));
     }
 
     @Operation(summary = "해당 소원에 대한 케이크 조회")
     @GetMapping("/{wishId}/{cakeId}")
-    public ResponseEntity<ApiResponse> getEachPresent(Principal principal, @PathVariable("wishId") Long wishId, @PathVariable("cakeId") Long cakeId) {
-        Long userId = getUserId(principal);
-        List<PresentResponseDto> response = cakeService.getEachPresent(userId, wishId, cakeId);
+    public ResponseEntity<ApiResponse> getEachPresent(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+                                                      @PathVariable("wishId") Long wishId, @PathVariable("cakeId") Long cakeId) {
+        List<PresentResponseDto> response = cakeService.getEachPresent(memberDetails.getId(), wishId, cakeId);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_PRESENT_MESSAGE.getMessage(), response));
-    }
-
-
-    private Long getUserId(Principal principal) {
-        if (isNull(principal)) {
-            throw new IllegalArgumentException(NULL_PRINCIPAL.getMessage());
-        }
-        return Long.valueOf(principal.getName());
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/PresentController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/PresentController.java
@@ -8,6 +8,7 @@ import com.sopterm.makeawish.dto.wish.WishResponseDTO;
 import com.sopterm.makeawish.service.CakeService;
 import com.sopterm.makeawish.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/presents")
+@Tag(name = "Presents", description = "유저의 친구들이 사용하는 API")
 public class PresentController {
 
     private final CakeService cakeService;

--- a/src/main/java/com/sopterm/makeawish/controller/UserController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/UserController.java
@@ -20,6 +20,8 @@ import static java.util.Objects.nonNull;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
+@SecurityRequirement(name = "Authorization")
+@Tag(name = "User", description = "마이페이지")
 public class UserController {
 
     private final WishService wishService;

--- a/src/main/java/com/sopterm/makeawish/controller/UserController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/UserController.java
@@ -1,23 +1,22 @@
 package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.domain.user.InternalMemberDetails;
 import com.sopterm.makeawish.dto.wish.MypageWishUpdateRequestDTO;
 import com.sopterm.makeawish.dto.wish.MypageWishUpdateResponseDTO;
 import com.sopterm.makeawish.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.security.Principal;
-
-import static com.sopterm.makeawish.common.message.ErrorMessage.NULL_PRINCIPAL;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
-@Tag(name = "User", description = "마이페이지")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/user")
@@ -29,24 +28,18 @@ public class UserController {
                     수정되지 않은 정보는 null 또는 원래의 정보 그대로 request로 전달부탁드립니다!
                     """)
     @PutMapping
-    public ResponseEntity<ApiResponse> updateWish(Principal principal, @RequestBody MypageWishUpdateRequestDTO requestDTO) {
-        MypageWishUpdateResponseDTO wish = wishService.updateWish(getUserId(principal), requestDTO);
+    public ResponseEntity<ApiResponse> updateWish(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+                                                  @RequestBody MypageWishUpdateRequestDTO requestDTO) {
+        MypageWishUpdateResponseDTO wish = wishService.updateWish(memberDetails.getId(), requestDTO);
         return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_INFO.getMessage(), wish));
     }
 
     @Operation(summary = "내 정보 가져오기")
     @GetMapping
-    public ResponseEntity<ApiResponse> getUserWish(Principal principal) {
-        MypageWishUpdateResponseDTO response = wishService.getMypageWish(getUserId(principal));
+    public ResponseEntity<ApiResponse> getUserWish(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails) {
+        MypageWishUpdateResponseDTO response = wishService.getMypageWish(memberDetails.getId());
         return nonNull(response)
                 ? ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_USER_INFO.getMessage(), response))
                 : ResponseEntity.ok(ApiResponse.fail(NO_WISH.getMessage()));
-    }
-
-    private Long getUserId(Principal principal) {
-        if (isNull(principal)) {
-            throw new IllegalArgumentException(NULL_PRINCIPAL.getMessage());
-        }
-        return Long.valueOf(principal.getName());
     }
 }

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -1,35 +1,38 @@
 package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
+import com.sopterm.makeawish.domain.user.InternalMemberDetails;
 import com.sopterm.makeawish.dto.wish.MainWishResponseDTO;
 import com.sopterm.makeawish.dto.wish.WishRequestDTO;
 import com.sopterm.makeawish.service.WishService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
-import java.security.Principal;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.NULL_PRINCIPAL;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/wishes")
+@SecurityRequirement(name = "Authorization")
 public class WishController {
 
 	private final WishService wishService;
 
 	@Operation(summary = "소원 링크 생성")
 	@PostMapping
-	public ResponseEntity<ApiResponse> createWish(Principal principal, @RequestBody WishRequestDTO requestDTO) {
-		Long wishId = wishService.createWish(getUserId(principal), requestDTO);
+	public ResponseEntity<ApiResponse> createWish(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+												  @RequestBody WishRequestDTO requestDTO) {
+		Long wishId = wishService.createWish(memberDetails.getId(), requestDTO);
 		return ResponseEntity
 			.created(getURI(wishId))
 			.body(ApiResponse.success(SUCCESS_CREATE_WISH.getMessage(), wishId));
@@ -37,8 +40,8 @@ public class WishController {
 
 	@Operation(summary = "메인 화면 조회")
 	@GetMapping("/main")
-	public ResponseEntity<ApiResponse> findMainWish(Principal principal) {
-		MainWishResponseDTO response = wishService.findMainWish(getUserId(principal));
+	public ResponseEntity<ApiResponse> findMainWish(@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails) {
+		MainWishResponseDTO response = wishService.findMainWish(memberDetails.getId());
 		return nonNull(response)
 			? ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_MAIN_WISH.getMessage(), response))
 			: ResponseEntity.status(NO_CONTENT).body(ApiResponse.success(NO_WISH.getMessage()));
@@ -50,13 +53,6 @@ public class WishController {
 		@RequestParam String url, @RequestParam String tag) throws Exception {
 		String response = wishService.getPresentInfo(url, tag);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_PARSE_HTML.getMessage(), response));
-	}
-
-	private Long getUserId(Principal principal) {
-		if (isNull(principal)) {
-			throw new IllegalArgumentException(NULL_PRINCIPAL.getMessage());
-		}
-		return Long.valueOf(principal.getName());
 	}
 
 	private URI getURI(Long id) {

--- a/src/main/java/com/sopterm/makeawish/controller/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sopterm/makeawish/controller/filter/JwtAuthenticationFilter.java
@@ -49,6 +49,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String parseJwt (HttpServletRequest request) {
         val headerAuth = request.getHeader("Authorization");
-        return (StringUtils.hasText(headerAuth)) ? headerAuth : null;
+        return (StringUtils.hasText(headerAuth)) ? headerAuth.split("Bearer ")[1] : null;
     }
 }

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
@@ -10,12 +10,12 @@ import java.util.List;
 public class InternalMemberDetails implements UserDetails {
     private final Collection<? extends GrantedAuthority> authorities;
     private final Long userId;
-    private final String username;
+    private final String userNickName;
     private final String authUserId;
 
     public InternalMemberDetails(User user) {
         this.userId = user.getId();
-        this.username = user.getUsername();
+        this.userNickName = user.getNickname();
         this.authUserId = user.getSocialId();
         this.authorities = List.of(new SimpleGrantedAuthority("MEMBER"));
     }
@@ -34,7 +34,7 @@ public class InternalMemberDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return username;
+        return userNickName;
     }
 
     @Override

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
@@ -10,12 +10,12 @@ import java.util.List;
 public class InternalMemberDetails implements UserDetails {
     private final Collection<? extends GrantedAuthority> authorities;
     private final Long userId;
-    private final String userNickName;
+    private final String nickname;
     private final String authUserId;
 
     public InternalMemberDetails(User user) {
         this.userId = user.getId();
-        this.userNickName = user.getNickname();
+        this.nickname = user.getNickname();
         this.authUserId = user.getSocialId();
         this.authorities = List.of(new SimpleGrantedAuthority("MEMBER"));
     }

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalMemberDetails.java
@@ -34,7 +34,7 @@ public class InternalMemberDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return userNickName;
+        return nickname;
     }
 
     @Override

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
@@ -36,7 +36,7 @@ public class InternalTokenManager {
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
         val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusHours(3).atZone(KST).toInstant();
+경                .toLocalDateTime().plusHours(2).atZone(KST).toInstant();
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
                 .setExpiration(Date.from(exp))

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
@@ -31,7 +31,7 @@ public class InternalTokenManager {
 
     private final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    public String createAuthToken(Long userId) {
+    public String createAuthAccessToken(Long userId) {
         val signatureAlgorithm= SignatureAlgorithm.HS256;
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
@@ -36,7 +36,20 @@ public class InternalTokenManager {
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
         val exp = new Date().toInstant().atZone(KST)
-                .toLocalDateTime().plusHours(4).atZone(KST).toInstant();
+                .toLocalDateTime().plusHours(3).atZone(KST).toInstant();
+        return Jwts.builder()
+                .setSubject(Long.toString(userId))
+                .setExpiration(Date.from(exp))
+                .signWith(signingKey, signatureAlgorithm)
+                .compact();
+    }
+
+    public String createAuthRefreshToken(Long userId) {
+        val signatureAlgorithm= SignatureAlgorithm.HS256;
+        val secretKeyBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
+        val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
+        val exp = new Date().toInstant().atZone(KST)
+                .toLocalDateTime().plusDays(14).atZone(KST).toInstant();
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
                 .setExpiration(Date.from(exp))

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
@@ -93,7 +93,7 @@ public class InternalTokenManager {
         return Jwts.parserBuilder()
                 .setSigningKey(DatatypeConverter.parseBase64Binary(jwtSecretKey))
                 .build()
-                .parseClaimsJws(token.split("Bearer ")[1])
+                .parseClaimsJws(token)
                 .getBody();
     }
 }

--- a/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/InternalTokenManager.java
@@ -36,7 +36,7 @@ public class InternalTokenManager {
         val secretKeyBytes = DatatypeConverter.parseBase64Binary(jwtSecretKey);
         val signingKey = new SecretKeySpec(secretKeyBytes, signatureAlgorithm.getJcaName());
         val exp = new Date().toInstant().atZone(KST)
-경                .toLocalDateTime().plusHours(2).atZone(KST).toInstant();
+                .toLocalDateTime().plusHours(2).atZone(KST).toInstant();
         return Jwts.builder()
                 .setSubject(Long.toString(userId))
                 .setExpiration(Date.from(exp))

--- a/src/main/java/com/sopterm/makeawish/domain/user/User.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/User.java
@@ -1,24 +1,20 @@
 package com.sopterm.makeawish.domain.user;
 
-import static jakarta.persistence.GenerationType.*;
-import static java.util.Objects.isNull;
-
+import com.sopterm.makeawish.domain.wish.AccountInfo;
+import com.sopterm.makeawish.domain.wish.Wish;
 import com.sopterm.makeawish.dto.auth.AuthSignInRequestDto;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
-import com.sopterm.makeawish.domain.wish.AccountInfo;
-import com.sopterm.makeawish.domain.wish.Wish;
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static java.util.Objects.isNull;
 
 @Entity
 @Getter
@@ -26,7 +22,7 @@ import com.sopterm.makeawish.domain.wish.Wish;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "member")
-public class User implements UserDetails {
+public class User {
 
     @Id @GeneratedValue(strategy = IDENTITY)
     @Column(name = "user_id")
@@ -64,41 +60,6 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "wisher")
     private final List<Wish> wishes = new ArrayList<>();
 
-    @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
-    }
-
-    @Override
-    public String getPassword() {
-        return null;
-    }
-
-    @Override
-    public String getUsername() {
-        return null;
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return false;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return false;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return false;
-    }
-
     @Builder
     public User(AuthSignInRequestDto authSignInRequestDto) {
         this.email = authSignInRequestDto.email();
@@ -107,6 +68,10 @@ public class User implements UserDetails {
         this.nickname = authSignInRequestDto.nickname();
         this.createdAt = authSignInRequestDto.createdAt();
         this.account = new AccountInfo(null, null, null);
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public void updateMemberProfile(

--- a/src/main/java/com/sopterm/makeawish/dto/auth/AuthSignInResponseDto.java
+++ b/src/main/java/com/sopterm/makeawish/dto/auth/AuthSignInResponseDto.java
@@ -6,11 +6,14 @@ import lombok.NonNull;
 @Builder
 public record AuthSignInResponseDto(
         @NonNull
-        String accessToken
+        String accessToken,
+        @NonNull
+        String refreshToken
 ) {
-        public static AuthSignInResponseDto from (String accessToken) {
+        public static AuthSignInResponseDto from (String accessToken, String refreshToken) {
             return AuthSignInResponseDto.builder()
                     .accessToken(accessToken)
+                    .refreshToken(refreshToken)
                     .build();
         }
 }

--- a/src/main/java/com/sopterm/makeawish/service/AuthService.java
+++ b/src/main/java/com/sopterm/makeawish/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.INVALID_USER.getMessage()));
         String refreshToken = tokenManager.createAuthRefreshToken(userId);
         user.updateRefreshToken(refreshToken);
-화        String accessToken = tokenManager.createAuthAccessToken(userId);
+        String accessToken = tokenManager.createAuthAccessToken(userId);
         return AuthGetTokenResponseDto.builder().
                 refreshToken(refreshToken)
                 .accessToken(accessToken)

--- a/src/main/java/com/sopterm/makeawish/service/AuthService.java
+++ b/src/main/java/com/sopterm/makeawish/service/AuthService.java
@@ -22,19 +22,21 @@ import java.util.Map;
 @Service
 @Component
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class AuthService {
     private final Map<SocialType, SocialLoginService> socialLogins = new EnumMap<>(SocialType.class);
     private final KakaoLoginService kakaoLoginService;
     private final InternalTokenManager tokenManager;
     private final UserRepository userRepository;
 
+    @Transactional
     public AuthSignInResponseDto socialLogin(String social, String code) throws JsonProcessingException {
         SocialType socialType = SocialType.from(social);
         SocialLoginService socialLoginService = socialLogins.get(socialType);
         return socialLoginService.socialLogin(code);
     }
 
+    @Transactional
     public AuthGetTokenResponseDto getToken(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.INVALID_USER.getMessage()));

--- a/src/main/java/com/sopterm/makeawish/service/AuthService.java
+++ b/src/main/java/com/sopterm/makeawish/service/AuthService.java
@@ -1,10 +1,16 @@
 package com.sopterm.makeawish.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sopterm.makeawish.common.message.ErrorMessage;
+import com.sopterm.makeawish.domain.user.InternalTokenManager;
 import com.sopterm.makeawish.domain.user.SocialType;
+import com.sopterm.makeawish.domain.user.User;
+import com.sopterm.makeawish.dto.auth.AuthGetTokenResponseDto;
 import com.sopterm.makeawish.dto.auth.AuthSignInResponseDto;
+import com.sopterm.makeawish.repository.UserRepository;
 import com.sopterm.makeawish.service.social.KakaoLoginService;
 import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
@@ -16,16 +22,29 @@ import java.util.Map;
 @Service
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AuthService {
     private final Map<SocialType, SocialLoginService> socialLogins = new EnumMap<>(SocialType.class);
     private final KakaoLoginService kakaoLoginService;
+    private final InternalTokenManager tokenManager;
+    private final UserRepository userRepository;
 
-    @Transactional
     public AuthSignInResponseDto socialLogin(String social, String code) throws JsonProcessingException {
         SocialType socialType = SocialType.from(social);
         SocialLoginService socialLoginService = socialLogins.get(socialType);
         return socialLoginService.socialLogin(code);
+    }
+
+    public AuthGetTokenResponseDto getToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.INVALID_USER.getMessage()));
+        String refreshToken = tokenManager.createAuthRefreshToken(userId);
+        user.updateRefreshToken(refreshToken);
+        String accessToken = tokenManager.createAuthToken(userId);
+        return AuthGetTokenResponseDto.builder().
+                refreshToken(refreshToken)
+                .accessToken(accessToken)
+                .build();
     }
 
     @PostConstruct

--- a/src/main/java/com/sopterm/makeawish/service/AuthService.java
+++ b/src/main/java/com/sopterm/makeawish/service/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
                 .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.INVALID_USER.getMessage()));
         String refreshToken = tokenManager.createAuthRefreshToken(userId);
         user.updateRefreshToken(refreshToken);
-        String accessToken = tokenManager.createAuthToken(userId);
+화        String accessToken = tokenManager.createAuthAccessToken(userId);
         return AuthGetTokenResponseDto.builder().
                 refreshToken(refreshToken)
                 .accessToken(accessToken)

--- a/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
+++ b/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
@@ -34,10 +34,10 @@ public class KakaoLoginService implements SocialLoginService {
         StringBuilder kakaoInfo = kakaoTokenManager.getKakaoInfo(kakaoAccessToken);
         JsonElement element = JsonParser.parseString(kakaoInfo.toString());
         User user = issueAccessToken(kakaoTokenManager.getAccessTokenByCode(element));
-        String token = tokenManager.createAuthToken(user.getId());
+        String accessToken = tokenManager.createAuthAccessToken(user.getId());
         String refreshToken = tokenManager.createAuthRefreshToken(user.getId());
         user.updateRefreshToken(refreshToken);
-        return new AuthSignInResponseDto(token,refreshToken);
+        return new AuthSignInResponseDto(accessToken,refreshToken);
     }
 
     private User issueAccessToken(AuthSignInRequestDto request) {

--- a/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
+++ b/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
@@ -35,7 +35,9 @@ public class KakaoLoginService implements SocialLoginService {
         JsonElement element = JsonParser.parseString(kakaoInfo.toString());
         User user = issueAccessToken(kakaoTokenManager.getAccessTokenByCode(element));
         String token = tokenManager.createAuthToken(user.getId());
-        return new AuthSignInResponseDto(token);
+        String refreshToken = tokenManager.createAuthRefreshToken(user.getId());
+        user.updateRefreshToken(refreshToken);
+        return new AuthSignInResponseDto(token,refreshToken);
     }
 
     private User issueAccessToken(AuthSignInRequestDto request) {


### PR DESCRIPTION
## ✨ 관련 이유
closes #56 

## ✨ 변경 사항 및 이유
토큰 로직이 변경됨에 따라, 토큰에서 유저를 검색하는 로직 변경
Refresh 토큰 로직 발급 로직 추가


![image](https://github.com/Make-A-Wish-Sopt/Make-A-Wish-Server/assets/78431728/a194898e-3fa8-46d6-9a70-edf2b013ecc7)
로그인 세션 정보를 어노테이션으로 간편하게 받을 수 있고, (Principal은 name메소드만 사용가능했지만) getId와 같은 커스텀한 메소드도 사용가능하다고 합니다! 그리고 Principal을 통해서 매 controller마다 유저를 검색해오는 중복되는 코드도 줄일 수 있어서 채택함
