### PR TITLE
[ADD] 타임존 KST 디폴트 설정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/config/TimezoneConfig.java
+++ b/src/main/java/com/sopterm/makeawish/config/TimezoneConfig.java
@@ -1,0 +1,16 @@
+package com.sopterm.makeawish.config;
+
+import java.util.TimeZone;
+
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+
+@Configuration
+public class TimezoneConfig {
+
+	@PostConstruct
+	public void init() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
+}


### PR DESCRIPTION


## ✨ 관련 이슈
closed #46 

## ✨ 변경 사항 및 이유
EC2 서버 내에서 UTC 타임존으로 설정되는 이슈를 해결하기 위함입니다.
Timezone 디폴트를 KST로 설정함으로써 EC2 내에서도 시간 관련 기능(LocalDateTime.now() 등)을 사용할 때 KST로 적용됩니다.



