### PR TITLE
[FEAT] 소원 단일 조회 API

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
+++ b/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
@@ -15,48 +15,50 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.web.client.HttpClientErrorException;
 
+import lombok.val;
+
 @RestControllerAdvice
 public class ErrorHandler {
 
 	@ExceptionHandler(EntityNotFoundException.class)
 	public ResponseEntity<ApiResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
-		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
 	}
 
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ApiResponse> handleIllegalArgumentExceptionException(IllegalArgumentException exception) {
-		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(HttpClientErrorException.class)
 	public ResponseEntity<ApiResponse> handleHttpClientErrorExceptionException(HttpClientErrorException exception) {
-		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(JsonProcessingException.class)
 	public ResponseEntity<ApiResponse> jsonProcessingException() {
-		ApiResponse response = ApiResponse.fail(CODE_PARSE_ERROR.getMessage());
+		val response = ApiResponse.fail(CODE_PARSE_ERROR.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(WrongAccessTokenException.class)
 	public ResponseEntity<ApiResponse> wrongAccessTokenException(WrongAccessTokenException exception) {
-		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.UNAUTHORIZED);
 	}
 
 	@ExceptionHandler(HttpRequestMethodNotSupportedException.class)
 	public ResponseEntity<ApiResponse> httpRequestMethodNotSupportedException() {
-		ApiResponse response = ApiResponse.fail(INVALID_HTTP_REQUEST.getMessage());
+		val response = ApiResponse.fail(INVALID_HTTP_REQUEST.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
 	}
 
 	@ExceptionHandler(AccessDeniedException.class)
 	public ResponseEntity<ApiResponse> accessDeniedException(AccessDeniedException exception) {
-		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
+++ b/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
@@ -2,6 +2,8 @@ package com.sopterm.makeawish.common;
 
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 
+import java.nio.file.AccessDeniedException;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sopterm.makeawish.exception.WrongAccessTokenException;
 import org.springframework.http.HttpStatus;
@@ -50,5 +52,11 @@ public class ErrorHandler {
 	public ResponseEntity<ApiResponse> httpRequestMethodNotSupportedException() {
 		ApiResponse response = ApiResponse.fail(INVALID_HTTP_REQUEST.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<ApiResponse> accessDeniedException(AccessDeniedException exception) {
+		ApiResponse response = ApiResponse.fail(exception.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/Util.java
+++ b/src/main/java/com/sopterm/makeawish/common/Util.java
@@ -1,0 +1,14 @@
+package com.sopterm.makeawish.common;
+
+public class Util {
+
+	private static final float FEE = 3.4f;
+
+	public static int getPriceAppliedFee(int price) {
+		return (int)Math.floor(price * (1 - FEE));
+	}
+
+	public static int getPricePercent(int totalPrice, int presentPrice) {
+		return (getPriceAppliedFee(totalPrice) / presentPrice) * 100;
+	}
+}

--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -23,7 +23,8 @@ public enum ErrorMessage {
 	INVALID_CODE("코드가 잘못되었습니다"),
 	WRONG_TOKEN("토큰이 비어있거나 잘못된 토큰입니다."),
 	SERVER_INTERNAL_ERROR("서버 내부 오류"),
-	INVALID_HTTP_REQUEST("지원하지 않는 HTTP Method 요청입니다.");
+	INVALID_HTTP_REQUEST("지원하지 않는 HTTP Method 요청입니다."),
+	FORBIDDEN("해당 데이터에 접근할 수 없습니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/SuccessMessage.java
@@ -21,6 +21,7 @@ public enum SuccessMessage {
 	NO_WISH("진행 중인 소원이 없습니다."),
 	SUCCESS_GET_MAIN_WISH("진행 중인 소원 조회 성공"),
 	SUCCESS_PARSE_HTML("HTML 파싱 성공"),
+	SUCCESS_GET_WISH("소원 단건 조회 성공"),
 
 	/** cake **/
 	SUCCESS_GET_ALL_CAKE("케이크 전체 조회 성공"),

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -15,10 +15,11 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.nonNull;
-import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -59,6 +60,16 @@ public class WishController {
 	) throws Exception {
 		val response = wishService.getPresentInfo(url, tag);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_PARSE_HTML.getMessage(), response));
+	}
+
+	@Operation(summary = "소원 단건 조회")
+	@GetMapping("/{wishId}")
+	public ResponseEntity<ApiResponse> findWish(
+		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+		@PathVariable Long wishId
+	) throws AccessDeniedException {
+		val response = wishService.findWish(memberDetails.getId(), wishId);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_WISH.getMessage(), response));
 	}
 
 	private URI getURI(Long id) {

--- a/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
@@ -1,6 +1,6 @@
 package com.sopterm.makeawish.dto.wish;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.*;
+import static com.sopterm.makeawish.common.Util.*;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -24,24 +24,15 @@ public record MainWishResponseDTO(
 		val name = Objects.nonNull(wish.getWisher().getAccount())
 			? wish.getWisher().getAccount().getName()
 			: wish.getWisher().getNickname();
-		val realTotalPrice = getTotalPriceAppliedFee(wish.getTotalPrice());
 
 		return MainWishResponseDTO.builder()
 			.wishId(wish.getId())
 			.name(name)
 			.cakeCount(wish.getPresents().size())
 			.dayCount(getRemainDay(wish.getEndAt()))
-			.price(realTotalPrice)
-			.percent(getPercent(wish.getPresentPrice(), realTotalPrice))
+			.price(getPriceAppliedFee(wish.getTotalPrice()))
+			.percent(getPricePercent(wish.getTotalPrice(), wish.getPresentPrice()))
 			.build();
-	}
-
-	private static int getTotalPriceAppliedFee(int price) {
-		return (int)Math.floor(price * (1 - 3.4));
-	}
-
-	private static int getPercent(int presentPrice, int totalPrice) {
-		return (totalPrice / presentPrice) * 100;
 	}
 
 	private static long getRemainDay(LocalDateTime endAt) {

--- a/src/main/java/com/sopterm/makeawish/dto/wish/UserWishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/UserWishResponseDTO.java
@@ -1,0 +1,27 @@
+package com.sopterm.makeawish.dto.wish;
+
+import static com.sopterm.makeawish.common.Util.*;
+
+import com.sopterm.makeawish.domain.wish.Wish;
+
+import lombok.Builder;
+
+@Builder
+public record UserWishResponseDTO(
+	String title,
+	String startAt,
+	String endAt,
+	int price,
+	int percent
+) {
+
+	public static UserWishResponseDTO of(Wish wish) {
+		return UserWishResponseDTO.builder()
+			.title(wish.getTitle())
+			.startAt(wish.getStartAt().toString())
+			.endAt(wish.getEndAt().toString())
+			.price(getPriceAppliedFee(wish.getTotalPrice()))
+			.percent(getPricePercent(wish.getTotalPrice(), wish.getPresentPrice()))
+			.build();
+	}
+}

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -4,6 +4,7 @@ import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 import static java.util.Objects.*;
 
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -92,6 +93,14 @@ public class WishService {
 			.timeout(5000).get()
 			.select("." + tag)
 			.toString();
+	}
+
+	public UserWishResponseDTO findWish(Long userId, Long wishId) throws AccessDeniedException {
+		Wish wish = getWish(wishId);
+		if (!wish.getWisher().getId().equals(userId)) {
+			throw new AccessDeniedException(FORBIDDEN.getMessage());
+		}
+		return UserWishResponseDTO.of(wish);
 	}
 
 	private User getUser(Long userId) {

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -43,19 +43,19 @@ public class WishService {
 		if (wishRepository.existsConflictWish(wisher, from, to, EXPIRY_DAY)) {
 			throw new IllegalArgumentException(EXIST_MAIN_WISH.getMessage());
 		}
-		Wish wish = requestDTO.toEntity(wisher);
+		val wish = requestDTO.toEntity(wisher);
 		return wishRepository.save(wish).getId();
 	}
 
 	@Transactional
 	public MypageWishUpdateResponseDTO updateWish(Long userId, MypageWishUpdateRequestDTO request) {
-		User user = getUser(userId);
+		val user = getUser(userId);
 		if (!wishRepository.existsWishByWisher(user)) {
 			throw new IllegalArgumentException(NO_EXIST_MAIN_WISH.getMessage());
 		}
 		user.updateMemberProfile(convertToTime(request.birthStartAt()), convertToTime(request.birthEndAt()), request.name(), request.bankName(), request.account(), request.phone());
 
-		Wish userWish = getUserWish(userId);
+		val userWish = getUserWish(userId);
 		if (nonNull(userWish)) {
 			userWish.updateWish(convertToTime(request.birthStartAt()), convertToTime(request.birthEndAt()), request.phone());
 		}
@@ -67,7 +67,7 @@ public class WishService {
 	}
 
 	public MypageWishUpdateResponseDTO getMypageWish(Long userId) {
-		Wish wish = wishRepository
+		val wish = wishRepository
 				.findFirstByWisherOrderByEndAtDesc(getUser(userId)).orElse(null);
 		return nonNull(wish) ? MypageWishUpdateResponseDTO.from(wish) : null;
 	}
@@ -77,7 +77,7 @@ public class WishService {
 	}
 
 	public MainWishResponseDTO findMainWish(Long userId) {
-		Wish wish = wishRepository
+		val wish = wishRepository
 			.findMainWish(getUser(userId), EXPIRY_DAY)
 			.orElse(null);
 		return nonNull(wish) ? MainWishResponseDTO.from(wish) : null;
@@ -96,7 +96,7 @@ public class WishService {
 	}
 
 	public UserWishResponseDTO findWish(Long userId, Long wishId) throws AccessDeniedException {
-		Wish wish = getWish(wishId);
+		val wish = getWish(wishId);
 		if (!wish.getWisher().getId().equals(userId)) {
 			throw new AccessDeniedException(FORBIDDEN.getMessage());
 		}
@@ -109,7 +109,7 @@ public class WishService {
 	}
 
 	private LocalDateTime convertToTime(String date) {
-		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+		val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
 		return LocalDateTime.parse(date + " 00:00", formatter);
 	}
 }


### PR DESCRIPTION


## ✨ 관련 이슈
closed #70 

## ✨ 변경 사항 및 이유
- 소원 단일 조회 API 구현했습니다~
- 중간중간 타입 통일화를 위해서 val 적용했어요.
- 수수료 적용 금액, 목표 달성률 구하는 메소드는 여럿 동일하게 사용되어 Util 클래스로 따로 빼서 리팩토링 시켰습니다.
- 날짜 관련은 72번 PR에서 ISO 8601로 모두 통일할게요!



