### PR TITLE
[ADD] 예외 처리 추가

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/Util.java
+++ b/src/main/java/com/sopterm/makeawish/common/Util.java
@@ -1,5 +1,12 @@
 package com.sopterm.makeawish.common;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import lombok.val;
+
 public class Util {
 
 	private static final float FEE = 3.4f;
@@ -10,5 +17,12 @@ public class Util {
 
 	public static int getPricePercent(int totalPrice, int presentPrice) {
 		return (getPriceAppliedFee(totalPrice) / presentPrice) * 100;
+	}
+
+	public static LocalDateTime convertToTime(String date) {
+		val instant = Instant
+			.from(DateTimeFormatter.ISO_DATE_TIME.parse(date))
+			.atZone(ZoneId.of("Asia/Seoul"));
+		return LocalDateTime.from(instant);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -15,6 +15,7 @@ public enum ErrorMessage {
 	NO_EXIST_MAIN_WISH("수정할 수 있는 소원링크가 없습니다."),
 	INCORRECT_WISH("본인의 소원 링크가 아닙니다"),
 	EXPIRED_BIRTHDAY_WISH("현재 생일 주간이 아닙니다."),
+	PAST_WISH("소원 링크 주간은 과거로 설정할 수 없습니다."),
 
 	/** user **/
 	INVALID_USER("인증되지 않은 회원입니다."),

--- a/src/main/java/com/sopterm/makeawish/controller/PublicController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/PublicController.java
@@ -2,6 +2,8 @@ package com.sopterm.makeawish.controller;
 
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 
+import java.nio.file.AccessDeniedException;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,7 +39,7 @@ public class PublicController {
 
 	@Operation(summary = "소원 링크 조회")
 	@GetMapping("/wishes/{wishId}")
-	public ResponseEntity<ApiResponse> findWish(@PathVariable Long wishId) {
+	public ResponseEntity<ApiResponse> findWish(@PathVariable Long wishId) throws AccessDeniedException {
 		val response = wishService.findWish(wishId);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_FIND_WISH.getMessage(), response));
 	}

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -87,8 +87,11 @@ public class WishController {
 
 	@Operation(summary = "소원 삭제")
 	@DeleteMapping
-	public ResponseEntity<ApiResponse> deleteWishes(@RequestBody WishIdRequestDTO requestDTO) {
-		wishService.deleteWishes(requestDTO);
+	public ResponseEntity<ApiResponse> deleteWishes(
+		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+		@RequestBody WishIdRequestDTO requestDTO
+	) {
+		wishService.deleteWishes(memberDetails.getId(), requestDTO);
 		return ResponseEntity.ok(success(SUCCESS_DELETE_WISHES.getMessage()));
 	}
 

--- a/src/main/java/com/sopterm/makeawish/dto/wish/WishRequestDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/WishRequestDTO.java
@@ -1,11 +1,6 @@
 package com.sopterm.makeawish.dto.wish;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-
-import lombok.val;
+import static com.sopterm.makeawish.common.Util.*;
 
 import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.domain.wish.Wish;
@@ -33,12 +28,5 @@ public record WishRequestDTO(
 			.phoneNumber(phone)
 			.wisher(wisher)
 			.build();
-	}
-
-	public static LocalDateTime convertToTime(String date) {
-		val instant = Instant
-			.from(DateTimeFormatter.ISO_DATE_TIME.parse(date))
-			.atZone(ZoneId.of("Asia/Seoul"));
-		return LocalDateTime.from(instant);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -60,8 +60,12 @@ public class WishService {
 		return UserCurrentWishResponseDTO.from(userWish, wisher);
 	}
 
-	public WishResponseDTO findWish(Long wishId) {
-		return WishResponseDTO.from(getWish(wishId));
+	public WishResponseDTO findWish(Long wishId) throws AccessDeniedException {
+		val wish = getWish(wishId);
+		if (wish.getEndAt().isBefore(LocalDateTime.now())) {
+			throw new AccessDeniedException(EXPIRE_WISH.getMessage());
+		}
+		return WishResponseDTO.from(wish);
 	}
 
 	public UserCurrentWishResponseDTO getCurrentUserWish(Long userId) {

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -41,6 +41,10 @@ public class WishService {
 		val wisher = getUser(userId);
 		val from = convertToTime(requestDTO.startDate());
 		val to = convertToTime(requestDTO.endDate());
+		val now = LocalDateTime.now();
+		if (from.isBefore(now) || to.isBefore(now)) {
+			throw new IllegalArgumentException(PAST_WISH.getMessage());
+		}
 		if (wishRepository.existsConflictWish(wisher, from, to, EXPIRY_DAY)) {
 			throw new IllegalArgumentException(EXIST_MAIN_WISH.getMessage());
 		}


### PR DESCRIPTION


## ✨ 관련 이슈
closed #79 

## ✨ 변경 사항 및 이유
- 종료된 소원은 public하게 조회할 수 없는 예외를 추가했습니다.
- 유저가 생성하지 않은 소원은 삭제할 수 없도록 유저의 소원만 필터링하는 메서드를 추가했습니다.
- 소원 주간을 과거로 설정할 수 없는 예외를 추가했습니다.
- ISO 포맷의 String 타입 날짜 데이터를 LocalDateTime 타입 데이터로 변환하는 메서드를 리팩토링하고 소원 수정에 추가 적용했습니다.



