### PR TITLE
[FIX] 유저의 최신 소원보다 과거 소원을 생성할 수 없는 이슈 해결

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -16,6 +16,7 @@ public enum ErrorMessage {
 	INCORRECT_WISH("본인의 소원 링크가 아닙니다"),
 	EXPIRED_BIRTHDAY_WISH("현재 생일 주간이 아닙니다."),
 	PAST_WISH("소원 링크 주간은 과거로 설정할 수 없습니다."),
+	INVALID_TERM("시작 일자는 종료 일자보다 미래일 수 없습니다."),
 
 	/** user **/
 	INVALID_USER("인증되지 않은 회원입니다."),

--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
@@ -67,9 +67,7 @@ public class WishRepositoryImpl implements WishCustomRepository {
 	private BooleanBuilder conflictTerm(LocalDateTime from, LocalDateTime to, int expiryDay) {
 		val booleanBuilder = new BooleanBuilder();
 		booleanBuilder.or(wish.startAt.between(from, to));
-		booleanBuilder.or(wish.endAt.between(from, to));
-		booleanBuilder.or(wish.endAt.after(from.minusDays(expiryDay)));
-		booleanBuilder.or(wish.endAt.eq(from.minusDays(expiryDay)));
+		booleanBuilder.or(wish.endAt.between(from.minusDays(expiryDay), to));
 		return booleanBuilder;
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -41,13 +41,8 @@ public class WishService {
 		val wisher = getUser(userId);
 		val from = convertToTime(requestDTO.startDate());
 		val to = convertToTime(requestDTO.endDate());
-		val now = LocalDateTime.now();
-		if (from.isBefore(now) || to.isBefore(now)) {
-			throw new IllegalArgumentException(PAST_WISH.getMessage());
-		}
-		if (wishRepository.existsConflictWish(wisher, from, to, EXPIRY_DAY)) {
-			throw new IllegalArgumentException(EXIST_MAIN_WISH.getMessage());
-		}
+		validateWishDate(wisher, from , to);
+
 		val wish = requestDTO.toEntity(wisher);
 		return wishRepository.save(wish).getId();
 	}
@@ -134,6 +129,19 @@ public class WishService {
 	private User getUser(Long userId) {
 		return userRepository.findById(userId)
 				.orElseThrow(() -> new EntityNotFoundException(INVALID_USER.getMessage()));
+	}
+
+	private void validateWishDate(User wisher, LocalDateTime from, LocalDateTime to) {
+		val now = LocalDateTime.now();
+		if (from.isBefore(now) || to.isBefore(now)) {
+			throw new IllegalArgumentException(PAST_WISH.getMessage());
+		}
+		if (from.isAfter(to)) {
+			throw new IllegalArgumentException(INVALID_TERM.getMessage());
+		}
+		if (wishRepository.existsConflictWish(wisher, from, to, EXPIRY_DAY)) {
+			throw new IllegalArgumentException(EXIST_MAIN_WISH.getMessage());
+		}
 	}
 
 	private List<Long> filterUserWishes(User user, List<Long> wishIds) {


### PR DESCRIPTION


## ✨ 관련 이슈
closed #80 

## ✨ 변경 사항 및 이유
- 날짜 충돌 쿼리를 수정했습니다.
- 유저의 소원 중 Wish.endAt보다 과거인 소원은 생성할 수 없는 이슈를 해결했습니다.



