### PR TITLE
[FIX] 진행 중인 소원 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
@@ -28,7 +28,7 @@ public class WishRepositoryImpl implements WishCustomRepository {
 			.from(wish)
 			.where(
 				wish.wisher.eq(wisher),
-				wish.startAt.before(now),
+				wish.startAt.loe(now),
 				wish.endAt.goe(now.minusDays(expiryDay))
 			)
 			.fetchFirst()


### PR DESCRIPTION


## ✨ 관련 이슈
closed #90 

## ✨ 변경 사항 및 이유
- 진행 중인 소원을 조회하는 쿼리를 수정했습니다.
- 변경 전에는 startAt.before(now)로 금일보다 과거의 소원을 조회하도록 했고,
- 변경 후에는 startAt.loe(now)로 금일이거나 금일보다 과거의 소원을 조회하도록 했습니다.



