### PR TITLE
[FIX] 기능 수정 및 예외 처리

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
+++ b/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
@@ -3,6 +3,7 @@ package com.sopterm.makeawish.common;
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
 
 import java.nio.file.AccessDeniedException;
+import java.time.format.DateTimeParseException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sopterm.makeawish.exception.WrongAccessTokenException;
@@ -60,5 +61,11 @@ public class ErrorHandler {
 	public ResponseEntity<ApiResponse> accessDeniedException(AccessDeniedException exception) {
 		val response = ApiResponse.fail(exception.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.FORBIDDEN);
+	}
+
+	@ExceptionHandler(DateTimeParseException.class)
+	public ResponseEntity<ApiResponse> dateTimeParseException() {
+		val response = ApiResponse.fail(FAULT_DATE_FORMATTER.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
+++ b/src/main/java/com/sopterm/makeawish/common/ErrorHandler.java
@@ -68,4 +68,10 @@ public class ErrorHandler {
 		val response = ApiResponse.fail(FAULT_DATE_FORMATTER.getMessage());
 		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
+
+	@ExceptionHandler(IllegalStateException.class)
+	public ResponseEntity<ApiResponse> illegalStateException(IllegalStateException exception) {
+		val response = ApiResponse.fail(exception.getMessage());
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+	}
 }

--- a/src/main/java/com/sopterm/makeawish/common/Util.java
+++ b/src/main/java/com/sopterm/makeawish/common/Util.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 import lombok.val;
 
@@ -19,7 +20,7 @@ public class Util {
 		return (getPriceAppliedFee(totalPrice) / presentPrice) * 100;
 	}
 
-	public static LocalDateTime convertToTime(String date) {
+	public static LocalDateTime convertToTime(String date) throws DateTimeParseException {
 		val instant = Instant
 			.from(DateTimeFormatter.ISO_DATE_TIME.parse(date))
 			.atZone(ZoneId.of("Asia/Seoul"));

--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -40,7 +40,8 @@ public enum ErrorMessage {
 	/** internal **/
 	SERVER_INTERNAL_ERROR("서버 내부 오류"),
 	INVALID_HTTP_REQUEST("지원하지 않는 HTTP Method 요청입니다."),
-	FORBIDDEN("해당 데이터에 접근할 수 없습니다.");
+	FORBIDDEN("해당 데이터에 접근할 수 없습니다."),
+	FAULT_DATE_FORMATTER("잘못된 날짜 형식입니다.");
 
 	private final String message;
 }

--- a/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
+++ b/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
@@ -78,11 +78,11 @@ public class Wish extends BaseEntity {
         this.totalPrice += price;
     }
 
-    public WishStatus getStatus() {
+    public WishStatus getStatus(int expiryDay) {
         val now = LocalDateTime.now();
         if (this.startAt.isAfter(now)) {
             return BEFORE;
-        } else if (this.startAt.isBefore(now) && this.endAt.isAfter(now)) {
+        } else if (this.startAt.isBefore(now) && this.endAt.plusDays(expiryDay).isAfter(now)) {
             return WHILE;
         } else {
             return END;

--- a/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
+++ b/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
@@ -79,13 +79,13 @@ public class Wish extends BaseEntity {
     }
 
     public WishStatus getStatus(int expiryDay) {
-        val now = LocalDateTime.now();
+        val now = LocalDateTime.now().toLocalDate().atStartOfDay();
         if (this.startAt.isAfter(now)) {
             return BEFORE;
-        } else if (this.startAt.isBefore(now) && this.endAt.plusDays(expiryDay).isAfter(now)) {
-            return WHILE;
-        } else {
+        } else if (this.endAt.plusDays(expiryDay).isBefore(now)) {
             return END;
+        } else {
+            return WHILE;
         }
     }
 

--- a/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
@@ -35,13 +35,13 @@ public record MainWishResponseDTO(
 			.dayCount(getRemainDay(wish))
 			.price(getPriceAppliedFee(wish.getTotalPrice()))
 			.percent(getPricePercent(wish.getTotalPrice(), wish.getPresentPrice()))
-			.status(wish.getStatus())
+			.status(wish.getStatus(0))
 			.build();
 	}
 
 	private static long getRemainDay(Wish wish) {
 		val now = LocalDateTime.now();
-		return wish.getStatus().equals(BEFORE)
+		return wish.getStatus(0).equals(BEFORE)
 			? ChronoUnit.DAYS.between(now, wish.getStartAt())
 			: ChronoUnit.DAYS.between(now, wish.getEndAt());
 	}

--- a/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/MainWishResponseDTO.java
@@ -1,12 +1,14 @@
 package com.sopterm.makeawish.dto.wish;
 
 import static com.sopterm.makeawish.common.Util.*;
+import static com.sopterm.makeawish.domain.wish.WishStatus.*;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 
 import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.domain.wish.WishStatus;
 
 import lombok.*;
 
@@ -17,7 +19,8 @@ public record MainWishResponseDTO(
 	int cakeCount,
 	long dayCount,
 	int price,
-	int percent
+	int percent,
+	WishStatus status
 ) {
 
 	public static MainWishResponseDTO from(Wish wish) {
@@ -29,14 +32,17 @@ public record MainWishResponseDTO(
 			.wishId(wish.getId())
 			.name(name)
 			.cakeCount(wish.getPresents().size())
-			.dayCount(getRemainDay(wish.getEndAt()))
+			.dayCount(getRemainDay(wish))
 			.price(getPriceAppliedFee(wish.getTotalPrice()))
 			.percent(getPricePercent(wish.getTotalPrice(), wish.getPresentPrice()))
+			.status(wish.getStatus())
 			.build();
 	}
 
-	private static long getRemainDay(LocalDateTime endAt) {
+	private static long getRemainDay(Wish wish) {
 		val now = LocalDateTime.now();
-		return ChronoUnit.DAYS.between(now, endAt);
+		return wish.getStatus().equals(BEFORE)
+			? ChronoUnit.DAYS.between(now, wish.getStartAt())
+			: ChronoUnit.DAYS.between(now, wish.getEndAt());
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishCustomRepository.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishCustomRepository.java
@@ -1,6 +1,7 @@
 package com.sopterm.makeawish.repository.wish;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import com.sopterm.makeawish.domain.user.User;
@@ -10,4 +11,5 @@ public interface WishCustomRepository {
 
 	Optional<Wish> findMainWish(User wisher, int expiryDay);
 	boolean existsConflictWish(User wisher, LocalDateTime startAt, LocalDateTime endAt, int expiryDay);
+	List<Wish> findEndWishes(User wisher, int expiryDay);
 }

--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishRepository.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishRepository.java
@@ -8,5 +8,4 @@ import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.domain.wish.Wish;
 
 public interface WishRepository extends JpaRepository<Wish, Long>, WishCustomRepository {
-	List<Wish> findByWisherOrderByStartAtDesc(User wisher);
 }

--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
@@ -28,7 +28,6 @@ public class WishRepositoryImpl implements WishCustomRepository {
 			.from(wish)
 			.where(
 				wish.wisher.eq(wisher),
-				wish.startAt.loe(now),
 				wish.endAt.goe(now.minusDays(expiryDay))
 			)
 			.fetchFirst()

--- a/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
+++ b/src/main/java/com/sopterm/makeawish/repository/wish/WishRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.sopterm.makeawish.repository.wish;
 import static com.sopterm.makeawish.domain.wish.QWish.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -48,6 +49,20 @@ public class WishRepositoryImpl implements WishCustomRepository {
 				conflictTerm(startAt, endAt, expiryDay)
 			)
 			.fetchFirst() != null;
+	}
+
+	@Override
+	public List<Wish> findEndWishes(User wisher, int expiryDay) {
+		val now = LocalDateTime.now();
+		return queryFactory
+			.select(wish)
+			.from(wish)
+			.where(
+				wish.wisher.eq(wisher),
+				wish.endAt.before(now.minusDays(expiryDay))
+			)
+			.orderBy(wish.startAt.desc())
+			.fetch();
 	}
 
 	private BooleanBuilder conflictTerm(LocalDateTime from, LocalDateTime to, int expiryDay) {

--- a/src/main/java/com/sopterm/makeawish/service/UserService.java
+++ b/src/main/java/com/sopterm/makeawish/service/UserService.java
@@ -34,7 +34,7 @@ public class UserService {
 		val wisher = getUser(userId);
 		val wish =  getUserMainWish(wisher);
 
-		val status = wish.getStatus();
+		val status = wish.getStatus(0);
 		if (status.equals(END)) {
 			throw new IllegalArgumentException(NOT_CURRENT_WISH.getMessage());
 		}

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -123,6 +123,6 @@ public class WishService {
 
 	private boolean isDeletable(User user, Long wishId) {
 		val wish = getWish(wishId);
-		return wish.getWisher().equals(user) && wish.getStatus().equals(WishStatus.END);
+		return wish.getWisher().equals(user) && wish.getStatus(EXPIRY_DAY).equals(WishStatus.END);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -9,6 +9,7 @@ import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.sopterm.makeawish.domain.wish.WishStatus;
 import com.sopterm.makeawish.dto.wish.*;
 
 import org.jsoup.Jsoup;
@@ -116,7 +117,12 @@ public class WishService {
 
 	private List<Long> filterUserWishes(User user, List<Long> wishIds) {
 		return wishIds.stream()
-			.filter(wishId -> getWish(wishId).getWisher().equals(user))
+			.filter(wishId -> isDeletable(user, wishId))
 			.toList();
+	}
+
+	private boolean isDeletable(User user, Long wishId) {
+		val wish = getWish(wishId);
+		return wish.getWisher().equals(user) && wish.getStatus().equals(WishStatus.END);
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -39,10 +39,12 @@ public class WishService {
 	@Transactional
 	public Long createWish(Long userId, WishRequestDTO requestDTO) {
 		val wisher = getUser(userId);
+		if (wishRepository.findMainWish(wisher, EXPIRY_DAY).isPresent()) {
+			throw new IllegalStateException(EXIST_MAIN_WISH.getMessage());
+		}
 		val from = convertToTime(requestDTO.startDate());
 		val to = convertToTime(requestDTO.endDate());
-		validateWishDate(wisher, from , to);
-
+		validateWishDate(wisher, from, to);
 		val wish = requestDTO.toEntity(wisher);
 		return wishRepository.save(wish).getId();
 	}

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -93,7 +93,7 @@ public class WishService {
 	}
 
 	public WishesResponseDTO findWishes(Long userId) {
-		val wishes = wishRepository.findByWisherOrderByStartAtDesc(getUser(userId));
+		val wishes = wishRepository.findEndWishes(getUser(userId), EXPIRY_DAY);
 		return WishesResponseDTO.of(wishes);
 	}
 


### PR DESCRIPTION


## ✨ 관련 이슈
closed #92 

## ✨ 변경 사항 및 이유
- 잘못된 날짜 포맷의 String 값으로 요청될 경우의 예외 처리 추가했습니다.
- MainWish(진행 중인 소원, 메인화면 조회)이 진행 전인 Entity도 조회되도록 합니다.
- 소원 진행 상태 값을 추가합니다. (메인 조회)
- 소원을 생성할 때 진행 중인 소원(MainWish)이 존재할 경우에 생성 불가한 예외 처리 추가했습니다.
- 종료된 소원만 삭제할 수 있도록 필터링 기능을 변경했습니다.
- 펀딩 종료 후 정산을 위한 7일을 위해 소원의 진행 상태를 가져오는 메소드에 expiryDay 적용하여 수정했습니다.
- 종료된 소원을 모아볼 수 있는 쿼리로 수정했습니다.


