### PR TITLE
[FIX] 소원 수정 API 및 유저 정보 API 변동사항 적용

### DIFF
--- a/src/main/java/com/sopterm/makeawish/controller/UserController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/UserController.java
@@ -2,7 +2,7 @@ package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.domain.user.InternalMemberDetails;
-import com.sopterm.makeawish.dto.user.UserAccountUpdateRequestDTO;
+import com.sopterm.makeawish.dto.user.UserAccountRequestDTO;
 import com.sopterm.makeawish.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,7 +43,7 @@ public class UserController {
     @PutMapping("/account")
     public ResponseEntity<ApiResponse> updateUserAccount(
             @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
-            @RequestBody UserAccountUpdateRequestDTO requestDTO
+            @RequestBody UserAccountRequestDTO requestDTO
     ) {
         val response = userService.updateUserAccount(memberDetails.getId(), requestDTO);
         return ResponseEntity

--- a/src/main/java/com/sopterm/makeawish/controller/UserController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/UserController.java
@@ -3,7 +3,6 @@ package com.sopterm.makeawish.controller;
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.domain.user.InternalMemberDetails;
 import com.sopterm.makeawish.dto.user.UserAccountUpdateRequestDTO;
-import com.sopterm.makeawish.dto.user.UserWishUpdateRequestDTO;
 import com.sopterm.makeawish.service.UserService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import static com.sopterm.makeawish.common.message.ErrorMessage.EXPIRED_BIRTHDAY_WISH;
 import static com.sopterm.makeawish.common.message.ErrorMessage.NO_EXIST_USER_ACCOUNT;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.nonNull;
@@ -29,27 +27,6 @@ import static java.util.Objects.nonNull;
 public class UserController {
 
     private final UserService userService;
-
-    @Operation(summary = "진행 중인 소원 수정", description = "수정되지 않은 정보는 null 또는 원래의 정보 그대로 전달")
-    @PutMapping("/wish")
-    public ResponseEntity<ApiResponse> updateUserMainWish(
-        @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
-        @RequestBody UserWishUpdateRequestDTO requestDTO
-    ) {
-        val wish = userService.updateUserMainWish(memberDetails.getId(), requestDTO);
-        return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_INFO.getMessage(), wish));
-    }
-
-    @Operation(summary = "진행 중인 소원 정보 조회")
-    @GetMapping("/wish")
-    public ResponseEntity<ApiResponse> findUserMainWish(
-        @Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
-    ) {
-        val response = userService.findUserMainWish(memberDetails.getId());
-        return nonNull(response)
-                ? ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_USER_INFO.getMessage(), response))
-                : ResponseEntity.ok(ApiResponse.fail(EXPIRED_BIRTHDAY_WISH.getMessage()));
-    }
 
     @Operation(summary = "유저 계좌 정보 가져오기")
     @GetMapping("/account")

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -2,6 +2,7 @@ package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.domain.user.InternalMemberDetails;
+import com.sopterm.makeawish.dto.user.UserWishUpdateRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishIdRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishRequestDTO;
 import com.sopterm.makeawish.service.WishService;
@@ -20,6 +21,8 @@ import java.net.URI;
 import java.nio.file.AccessDeniedException;
 
 import static com.sopterm.makeawish.common.ApiResponse.*;
+import static com.sopterm.makeawish.common.message.ErrorMessage.*;
+import static com.sopterm.makeawish.common.message.ErrorMessage.NO_WISH;
 import static com.sopterm.makeawish.common.message.SuccessMessage.*;
 import static java.util.Objects.nonNull;
 import static org.springframework.http.HttpStatus.*;
@@ -93,6 +96,27 @@ public class WishController {
 	) {
 		wishService.deleteWishes(memberDetails.getId(), requestDTO);
 		return ResponseEntity.ok(success(SUCCESS_DELETE_WISHES.getMessage()));
+	}
+
+	@Operation(summary = "진행 중인 소원 수정", description = "수정되지 않은 정보는 null 또는 원래의 정보 그대로 전달")
+	@PutMapping("/main")
+	public ResponseEntity<ApiResponse> updateUserMainWish(
+		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+		@RequestBody UserWishUpdateRequestDTO requestDTO
+	) {
+		val wish = wishService.updateUserMainWish(memberDetails.getId(), requestDTO);
+		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_INFO.getMessage(), wish));
+	}
+
+	@Operation(summary = "진행 중인 소원 정보 조회")
+	@GetMapping("/main")
+	public ResponseEntity<ApiResponse> findUserMainWish(
+		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
+	) {
+		val response = wishService.findUserMainWish(memberDetails.getId());
+		return nonNull(response)
+			? ResponseEntity.ok(ApiResponse.success(SUCCESS_GET_USER_INFO.getMessage(), response))
+			: ResponseEntity.ok(ApiResponse.fail(EXPIRED_BIRTHDAY_WISH.getMessage()));
 	}
 
 	private URI getURI(Long id) {

--- a/src/main/java/com/sopterm/makeawish/controller/WishController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/WishController.java
@@ -2,7 +2,7 @@ package com.sopterm.makeawish.controller;
 
 import com.sopterm.makeawish.common.ApiResponse;
 import com.sopterm.makeawish.domain.user.InternalMemberDetails;
-import com.sopterm.makeawish.dto.user.UserWishUpdateRequestDTO;
+import com.sopterm.makeawish.dto.wish.UserWishUpdateRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishIdRequestDTO;
 import com.sopterm.makeawish.dto.wish.WishRequestDTO;
 import com.sopterm.makeawish.service.WishService;
@@ -15,6 +15,7 @@ import lombok.val;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -36,6 +37,7 @@ public class WishController {
 
 	private final WishService wishService;
 
+	//TODO: 이미지 업로드 기능 구현 후 반영
 	@Operation(summary = "소원 링크 생성")
 	@PostMapping
 	public ResponseEntity<ApiResponse> createWish(
@@ -99,17 +101,19 @@ public class WishController {
 	}
 
 	@Operation(summary = "진행 중인 소원 수정", description = "수정되지 않은 정보는 null 또는 원래의 정보 그대로 전달")
-	@PutMapping("/main")
+	@PutMapping("/progress")
 	public ResponseEntity<ApiResponse> updateUserMainWish(
 		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails,
+		@RequestParam(name = "imageFile", required = false) MultipartFile imageFile,
 		@RequestBody UserWishUpdateRequestDTO requestDTO
 	) {
-		val wish = wishService.updateUserMainWish(memberDetails.getId(), requestDTO);
+		val wish = wishService
+			.updateUserMainWish(memberDetails.getId(), imageFile, requestDTO);
 		return ResponseEntity.ok(ApiResponse.success(SUCCESS_UPDATE_USER_INFO.getMessage(), wish));
 	}
 
 	@Operation(summary = "진행 중인 소원 정보 조회")
-	@GetMapping("/main")
+	@GetMapping("/progress")
 	public ResponseEntity<ApiResponse> findUserMainWish(
 		@Parameter(hidden = true) @AuthenticationPrincipal InternalMemberDetails memberDetails
 	) {

--- a/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
+++ b/src/main/java/com/sopterm/makeawish/domain/wish/Wish.java
@@ -3,6 +3,8 @@ package com.sopterm.makeawish.domain.wish;
 import com.sopterm.makeawish.domain.BaseEntity;
 import com.sopterm.makeawish.domain.Present;
 import com.sopterm.makeawish.domain.user.User;
+import com.sopterm.makeawish.dto.wish.UserWishUpdateRequestDTO;
+
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -86,6 +88,24 @@ public class Wish extends BaseEntity {
             return END;
         } else {
             return WHILE;
+        }
+    }
+
+    public void updateContent(String imageUrl, Integer price, String title, String hint, String initial) {
+        if (nonNull(imageUrl)) {
+            this.presentImageUrl = imageUrl;
+        }
+        if (nonNull(price)) {
+            this.presentPrice = price;
+        }
+        if (nonNull(title)) {
+            this.title = title;
+        }
+        if (nonNull(hint)) {
+            this.hint = hint;
+        }
+        if (nonNull(initial)) {
+            this.initial = initial;
         }
     }
 

--- a/src/main/java/com/sopterm/makeawish/dto/user/UserAccountRequestDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/user/UserAccountRequestDTO.java
@@ -2,4 +2,8 @@ package com.sopterm.makeawish.dto.user;
 
 import com.sopterm.makeawish.domain.user.AccountInfo;
 
-public record UserAccountUpdateRequestDTO(AccountInfo accountInfo) { }
+public record UserAccountRequestDTO(
+	AccountInfo accountInfo,
+	String phone
+) {
+}

--- a/src/main/java/com/sopterm/makeawish/dto/user/UserAccountResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/user/UserAccountResponseDTO.java
@@ -7,11 +7,16 @@ import com.sopterm.makeawish.domain.user.User;
 import lombok.Builder;
 
 @Builder
-public record UserAccountResponseDTO(Long id, AccountInfo accountInfo) {
+public record UserAccountResponseDTO(
+	Long id,
+	AccountInfo accountInfo,
+	String phone
+) {
 	public static UserAccountResponseDTO of(User user) {
 		return UserAccountResponseDTO.builder()
 			.id(user.getId())
 			.accountInfo(getUserAccount(user))
+			.phone(user.getPhoneNumber())
 			.build();
 	}
 

--- a/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateRequestDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateRequestDTO.java
@@ -4,12 +4,12 @@ import lombok.Builder;
 
 @Builder
 public record UserWishUpdateRequestDTO(
-    String startDate,
-    String endDate,
-    String name,
-    String bankName,
-    String account,
-    String phone,
+	String startDate,
+	String endDate,
+	String name,
+	String bankName,
+	String account,
+	String phone,
 	String imageUrl,
 	Integer price,
 	String title,

--- a/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateRequestDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateRequestDTO.java
@@ -1,4 +1,4 @@
-package com.sopterm.makeawish.dto.user;
+package com.sopterm.makeawish.dto.wish;
 
 import lombok.Builder;
 
@@ -9,6 +9,11 @@ public record UserWishUpdateRequestDTO(
     String name,
     String bankName,
     String account,
-    String phone
+    String phone,
+	String imageUrl,
+	Integer price,
+	String title,
+	String hint,
+	String initial
 ) {
 }

--- a/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/wish/UserWishUpdateResponseDTO.java
@@ -1,10 +1,12 @@
-package com.sopterm.makeawish.dto.user;
+package com.sopterm.makeawish.dto.wish;
 
 import static java.util.Objects.*;
 
 import com.sopterm.makeawish.domain.user.AccountInfo;
 import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.domain.wish.WishStatus;
+
 import lombok.Builder;
 
 @Builder
@@ -12,7 +14,12 @@ public record UserWishUpdateResponseDTO(
 	String startDate,
 	String endDate,
 	String phone,
-	AccountInfo accountInfo
+	AccountInfo accountInfo,
+	String imageUrl,
+	String title,
+	String initial,
+	String hint,
+	WishStatus status
 ) {
 	public static UserWishUpdateResponseDTO of(User user, Wish wish) {
 		return UserWishUpdateResponseDTO.builder()
@@ -20,6 +27,11 @@ public record UserWishUpdateResponseDTO(
 			.endDate(wish.getEndAt().toString())
 			.phone(user.getPhoneNumber())
 			.accountInfo(nonNull(user.getAccount()) ? user.getAccount() : null)
+			.imageUrl(wish.getPresentImageUrl())
+			.title(wish.getTitle())
+			.initial(wish.getInitial())
+			.hint(wish.getHint())
+			.status(wish.getStatus(0))
 			.build();
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/UserService.java
+++ b/src/main/java/com/sopterm/makeawish/service/UserService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.sopterm.makeawish.domain.user.User;
 import com.sopterm.makeawish.dto.user.UserAccountResponseDTO;
-import com.sopterm.makeawish.dto.user.UserAccountUpdateRequestDTO;
+import com.sopterm.makeawish.dto.user.UserAccountRequestDTO;
 import com.sopterm.makeawish.repository.UserRepository;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -28,15 +28,15 @@ public class UserService {
 	}
 
 	@Transactional
-	public UserAccountResponseDTO updateUserAccount(Long userId, UserAccountUpdateRequestDTO requestDTO) {
+	public UserAccountResponseDTO updateUserAccount(Long userId, UserAccountRequestDTO requestDTO) {
 		val wisher = getUser(userId);
 		if (isNull(requestDTO.accountInfo())) {
 			throw new IllegalArgumentException(NO_EXIST_USER_ACCOUNT.getMessage());
 		}
-		wisher.updateAccount(
-			requestDTO.accountInfo().getName(),
+		wisher.updateAccount(requestDTO.accountInfo().getName(),
 			requestDTO.accountInfo().getBank(),
 			requestDTO.accountInfo().getAccount());
+		wisher.updatePhoneNumber(requestDTO.phone());
 		return UserAccountResponseDTO.of(wisher);
 	}
 

--- a/src/main/java/com/sopterm/makeawish/service/UserService.java
+++ b/src/main/java/com/sopterm/makeawish/service/UserService.java
@@ -1,21 +1,15 @@
 package com.sopterm.makeawish.service;
 
-import static com.sopterm.makeawish.common.Util.*;
 import static com.sopterm.makeawish.common.message.ErrorMessage.*;
-import static com.sopterm.makeawish.domain.wish.WishStatus.*;
 import static java.util.Objects.*;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sopterm.makeawish.domain.user.User;
-import com.sopterm.makeawish.domain.wish.Wish;
 import com.sopterm.makeawish.dto.user.UserAccountResponseDTO;
 import com.sopterm.makeawish.dto.user.UserAccountUpdateRequestDTO;
-import com.sopterm.makeawish.dto.user.UserWishUpdateResponseDTO;
-import com.sopterm.makeawish.dto.user.UserWishUpdateRequestDTO;
 import com.sopterm.makeawish.repository.UserRepository;
-import com.sopterm.makeawish.repository.wish.WishRepository;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -27,34 +21,6 @@ import lombok.val;
 public class UserService {
 
 	private final UserRepository userRepository;
-	private final WishRepository wishRepository;
-
-	@Transactional
-	public UserWishUpdateResponseDTO updateUserMainWish(Long userId, UserWishUpdateRequestDTO request) {
-		val wisher = getUser(userId);
-		val wish =  getUserMainWish(wisher);
-
-		val status = wish.getStatus(0);
-		if (status.equals(END)) {
-			throw new IllegalArgumentException(NOT_CURRENT_WISH.getMessage());
-		}
-		if (status.equals(BEFORE)) {
-			val startDate = nonNull(request.startDate()) ? convertToDate(request.startDate()) : null;
-			val endDate = nonNull(request.endDate()) ? convertToDate(request.endDate()) : null;
-			wish.updateTerm(startDate, endDate);
-		}
-		if (status.equals(BEFORE) || status.equals(WHILE)) {
-			wisher.updateProfile(request.name(), request.bankName(), request.account(), request.phone());
-		}
-
-		return UserWishUpdateResponseDTO.of(wisher, wish);
-	}
-
-	public UserWishUpdateResponseDTO findUserMainWish(Long userId) {
-		val wisher = getUser(userId);
-		val wish =  getUserMainWish(wisher);
-		return UserWishUpdateResponseDTO.of(wisher, wish);
-	}
 
 	public UserAccountResponseDTO getUserAccount(Long userId) {
 		val wisher = getUser(userId);
@@ -77,11 +43,5 @@ public class UserService {
 	private User getUser(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new EntityNotFoundException(INVALID_USER.getMessage()));
-	}
-
-	private Wish getUserMainWish(User user) {
-		return   wishRepository
-			.findMainWish(user, 0)
-			.orElseThrow(() -> new EntityNotFoundException(NO_WISH.getMessage()));
 	}
 }

--- a/src/main/java/com/sopterm/makeawish/service/UserService.java
+++ b/src/main/java/com/sopterm/makeawish/service/UserService.java
@@ -33,7 +33,8 @@ public class UserService {
 		if (isNull(requestDTO.accountInfo())) {
 			throw new IllegalArgumentException(NO_EXIST_USER_ACCOUNT.getMessage());
 		}
-		wisher.updateAccount(requestDTO.accountInfo().getName(),
+		wisher.updateAccount(
+			requestDTO.accountInfo().getName(),
 			requestDTO.accountInfo().getBank(),
 			requestDTO.accountInfo().getAccount());
 		wisher.updatePhoneNumber(requestDTO.phone());


### PR DESCRIPTION


## ✨ 관련 이슈
closed #104 
closed #107 

## ✨ 변경 사항 및 이유
- 진행 중인 소원 조회 및 수정 API 경로 변경했습니다. (`/api/v1/wishes/progress`)
- 각 DTO 내용 변동사항에 맞춰 변경했습니다.
- 통일성을 위해 UserAccountUpdateDTO를 UserAccountDTO 파일명으로 변경했습니다.

