### PR TITLE
[ADD] response 값 추가

### DIFF
--- a/src/main/java/com/sopterm/makeawish/dto/auth/AuthSignInResponseDTO.java
+++ b/src/main/java/com/sopterm/makeawish/dto/auth/AuthSignInResponseDTO.java
@@ -8,12 +8,15 @@ public record AuthSignInResponseDTO(
         @NonNull
         String accessToken,
         @NonNull
-        String refreshToken
+        String refreshToken,
+        @NonNull
+        String nickName
 ) {
-        public static AuthSignInResponseDTO from (String accessToken, String refreshToken) {
+        public static AuthSignInResponseDTO from (String accessToken, String refreshToken, String nickName) {
             return AuthSignInResponseDTO.builder()
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
+                    .nickName(nickName)
                     .build();
         }
 }

--- a/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
+++ b/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
@@ -36,7 +36,7 @@ public class KakaoLoginService implements SocialLoginService {
         val accessToken = tokenManager.createAuthAccessToken(user.getId());
         val refreshToken = tokenManager.createAuthRefreshToken(user.getId());
         user.updateRefreshToken(refreshToken);
-        return new AuthSignInResponseDTO(accessToken,refreshToken);
+        return new AuthSignInResponseDTO(accessToken,refreshToken,user.getNickname());
     }
 
     private User issueAccessToken(AuthSignInRequestDTO request) {


### PR DESCRIPTION
## ✨ 관련 이슈
closed #119 


## ✨ 변경 사항 및 이유
- Resonse값에 닉네임을 추가하였습니다.
- 닉네임은 필수값이기 때문에, 카카오 로그인시 닉네임에 Null이 들어올 경우가 없어서, 따로 null처리를 진행하지 않았습니다.

메인화면 조회할 때 생성된 소원이 없어도 화면에 띄울 닉네임이 필요 & 그 외에도 sns 공유하기 등에서 닉네임이 필요
## ✨ PR Point
<img width="743" alt="image" src="https://github.com/Make-A-Wish-Sopt/Make-A-Wish-Server/assets/78431728/8e56811f-8d23-4cfa-8e57-e5156fe3661f">

