### PR TITLE
[CHORE] 카카오 소셜로그인 RequestParam RedirectURI 를 넣도록 수정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/controller/AuthController.java
+++ b/src/main/java/com/sopterm/makeawish/controller/AuthController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_GET_REFRESH_TOKEN;
 import static com.sopterm.makeawish.common.message.SuccessMessage.SUCCESS_SIGN_IN;
@@ -29,8 +26,8 @@ public class AuthController {
     private final AuthService authService;
     @Operation(summary = "카카오 소셜 로그인", description = "kakao 인증 서버에서 발급받은 accessToken header에 request")
     @PostMapping("/kakao/callback")
-    public ResponseEntity<ApiResponse> signIn(@RequestHeader String code) throws JsonProcessingException {
-        val responseDto = authService.socialLogin("KAKAO", code);
+    public ResponseEntity<ApiResponse> signIn(@RequestHeader String code, @RequestParam String redirectUri) throws JsonProcessingException {
+        val responseDto = authService.socialLogin("KAKAO", code, redirectUri);
         val apiResponse = ApiResponse.success(SUCCESS_SIGN_IN.getMessage(), responseDto);
         return ResponseEntity.ok(apiResponse);
     }

--- a/src/main/java/com/sopterm/makeawish/domain/user/KakaoTokenManager.java
+++ b/src/main/java/com/sopterm/makeawish/domain/user/KakaoTokenManager.java
@@ -33,10 +33,8 @@ public class KakaoTokenManager {
     private String kakaoUrl;
     @Value("${social.client-id}")
     private String clientId;
-    @Value("${social.redirect-uri}")
-    private String redirectUri;
 
-    public String getAccessTokenByCode(String code) throws JsonProcessingException {
+    public String getAccessTokenByCode(String code, String redirectUri) throws JsonProcessingException {
         // HTTP Header 생성
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);

--- a/src/main/java/com/sopterm/makeawish/service/AuthService.java
+++ b/src/main/java/com/sopterm/makeawish/service/AuthService.java
@@ -29,10 +29,10 @@ public class AuthService {
     private final UserRepository userRepository;
 
     @Transactional
-    public AuthSignInResponseDTO socialLogin(String social, String code) throws JsonProcessingException {
+    public AuthSignInResponseDTO socialLogin(String social, String code, String redirectUri) throws JsonProcessingException {
         val socialType = SocialType.from(social);
         val socialLoginService = socialLogins.get(socialType);
-        return socialLoginService.socialLogin(code);
+        return socialLoginService.socialLogin(code, redirectUri);
     }
 
     @Transactional

--- a/src/main/java/com/sopterm/makeawish/service/SocialLoginService.java
+++ b/src/main/java/com/sopterm/makeawish/service/SocialLoginService.java
@@ -6,5 +6,5 @@ import com.sopterm.makeawish.dto.auth.AuthSignInResponseDTO;
 @FunctionalInterface
 public interface SocialLoginService {
 
-    AuthSignInResponseDTO socialLogin(String code) throws JsonProcessingException;
+    AuthSignInResponseDTO socialLogin(String code, String redirectUri) throws JsonProcessingException;
 }

--- a/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
+++ b/src/main/java/com/sopterm/makeawish/service/social/KakaoLoginService.java
@@ -23,10 +23,10 @@ public class KakaoLoginService implements SocialLoginService {
     private final KakaoTokenManager kakaoTokenManager;
 
     @Override
-    public AuthSignInResponseDTO socialLogin(String code) {
+    public AuthSignInResponseDTO socialLogin(String code, String redirectUri) {
         String kakaoAccessToken = null;
         try {
-            kakaoAccessToken = kakaoTokenManager.getAccessTokenByCode(code);
+            kakaoAccessToken = kakaoTokenManager.getAccessTokenByCode(code, redirectUri);
         } catch (JsonProcessingException j) {
             throw new IllegalArgumentException(CODE_PARSE_ERROR.getMessage());
         }


### PR DESCRIPTION
## ✨ 관련 이슈
closed #131 

## ✨ 변경 사항 및 이유
카카오 소셜로그인시, request param에 redirct-uri 값을 받도록 수정하였습니다.

## ✨ PR Point
추후, yml에 redirct_uri 값을 없애줘야합니다

