### PR TITLE
[FIX] 예외처리 수정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
+++ b/src/main/java/com/sopterm/makeawish/common/message/ErrorMessage.java
@@ -10,7 +10,7 @@ public enum ErrorMessage {
 	/** wish **/
 	EXPIRE_WISH("주간이 끝난 소원 링크입니다."),
 	NO_WISH("유저가 생성한 소원링크가 없습니다"),
-	INVALID_WISH("존재하지 않는 소원 링크입니다."),
+	INVALID_WISH("유효하지 않은 소원 링크입니다."),
 	EXIST_MAIN_WISH("이미 진행 중인 소원 링크가 있습니다."),
 	NOT_CURRENT_WISH("소원을 수정할 수 있는 기간이 아닙니다."),
 	NO_EXIST_MAIN_WISH("수정할 수 있는 소원링크가 없습니다."),

--- a/src/main/java/com/sopterm/makeawish/service/WishService.java
+++ b/src/main/java/com/sopterm/makeawish/service/WishService.java
@@ -50,8 +50,8 @@ public class WishService {
 
 	public WishResponseDTO findWish(Long wishId) throws AccessDeniedException {
 		val wish = getWish(wishId);
-		if (wish.getEndAt().isBefore(LocalDateTime.now())) {
-			throw new AccessDeniedException(EXPIRE_WISH.getMessage());
+		if (!wish.getStatus(0).equals(WHILE)) {
+			throw new AccessDeniedException(INVALID_WISH.getMessage());
 		}
 		return WishResponseDTO.from(wish);
 	}
@@ -155,7 +155,7 @@ public class WishService {
 
 	private void deleteUserWish(User wisher, Wish wish) {
 		if (wish.getWisher().equals(wisher)) {
-			wish.getPresents().forEach(presentRepository::delete);
+			presentRepository.deleteAll(wish.getPresents());
 			wishRepository.delete(wish);
 		}
 	}


### PR DESCRIPTION


## ✨ 관련 이슈
closed #137 

## ✨ 변경 사항 및 이유
- public하게 소원 링크를 조회하는 과정에서 소원 상태 값이 WHILE이 아닌 경우에 403 예외처리하여 접근하지 못하도록 추가 처리했습니다.
- 포괄적인 의미를 위해서 INVALID_WISH 값을 "유효하지 않은 소원"으로 워딩 변경했습니다.
- 가독성을 위해 deleteWish 메서드 내 함수를 일부 수정했습니다. (기능 및 동작 결과는 같음)


