### PR TITLE
[ADD] 캐시 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,12 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+    // caffiene cache
+    implementation "com.github.ben-manes.caffeine:caffeine:3.1.8"
 }
 
 test {

--- a/src/main/java/com/sopterm/makeawish/config/cache/CacheConfig.java
+++ b/src/main/java/com/sopterm/makeawish/config/cache/CacheConfig.java
@@ -1,0 +1,31 @@
+package com.sopterm.makeawish.config.cache;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        SimpleCacheManager manager = new SimpleCacheManager();
+        List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+                .map(cache -> new CaffeineCache(cache.getCacheName(),
+                        Caffeine.newBuilder().recordStats().expireAfterWrite(cache.getTimeToLive(), TimeUnit.MINUTES)
+                                .maximumSize(cache.getMaxSize())
+                                .build())).collect(Collectors.toList());
+
+        manager.setCaches(caches);
+        return manager;
+    }
+}

--- a/src/main/java/com/sopterm/makeawish/config/cache/CacheType.java
+++ b/src/main/java/com/sopterm/makeawish/config/cache/CacheType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheType {
 
-    PRESENT_COUNT("presents", 3000, 30);
+    PRESENT_COUNT("allPresentsList", 3000, 30);
 
     private final String cacheName;
     private final int maxSize;

--- a/src/main/java/com/sopterm/makeawish/config/cache/CacheType.java
+++ b/src/main/java/com/sopterm/makeawish/config/cache/CacheType.java
@@ -1,0 +1,15 @@
+package com.sopterm.makeawish.config.cache;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+
+    PRESENT_COUNT("presents", 3000, 30);
+
+    private final String cacheName;
+    private final int maxSize;
+    private final int timeToLive;
+}

--- a/src/main/java/com/sopterm/makeawish/service/CakeService.java
+++ b/src/main/java/com/sopterm/makeawish/service/CakeService.java
@@ -11,6 +11,7 @@ import com.sopterm.makeawish.repository.CakeRepository;
 import com.sopterm.makeawish.repository.PresentRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.*;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -127,6 +128,7 @@ public class CakeService {
         return cakeRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(INVALID_CAKE.getMessage()));
     }
 
+    @Cacheable(cacheNames = "allPresentsList")
     public List<PresentDTO> getPresents(Long userId, Long wishId) {
         val wish = wishService.getWish(wishId);
         if (!isRightWisher(userId, wish))

--- a/src/test/java/com/sopterm/makeawish/config/CacheTest.java
+++ b/src/test/java/com/sopterm/makeawish/config/CacheTest.java
@@ -1,0 +1,83 @@
+package com.sopterm.makeawish.config;
+
+import com.sopterm.makeawish.common.Util;
+import com.sopterm.makeawish.domain.user.AccountInfo;
+import com.sopterm.makeawish.domain.user.SocialType;
+import com.sopterm.makeawish.domain.user.User;
+import com.sopterm.makeawish.domain.wish.Wish;
+import com.sopterm.makeawish.repository.UserRepository;
+import com.sopterm.makeawish.repository.wish.WishRepository;
+import com.sopterm.makeawish.service.CakeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.CacheManager;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.logging.Logger;
+
+@SpringBootTest
+public class CacheTest {
+    @Autowired
+    CacheManager cacheManager;
+
+    @Autowired
+    CakeService cakeService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    WishRepository wishRepository;
+
+    @Test
+    @Transactional
+    @DisplayName("로컬 캐시에 있으면 캐시에서 값을 가져온다.")
+    void 로컬_캐시_가져오기_성공() {
+        // given
+        User user = userRepository.save(createUser());
+        Wish wish = wishRepository.save(createWish(user));
+
+        for (int i = 0; i < 10; i++) {
+            long start = System.currentTimeMillis();
+            cakeService.getPresents(user.getId(), wish.getId());
+            long end = System.currentTimeMillis();
+            System.out.println("time = " + (end - start));
+        }
+    }
+
+    private String getLocalDateTime(int plusDays) {
+        LocalDateTime date = LocalDateTime.now().plusDays(plusDays);
+        return date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss+00:00"));
+    }
+
+
+    private User createUser() {
+        AccountInfo accountInfo = new AccountInfo("김아무", "bank", "account");
+        return User.builder()
+                .email("kim@email.com")
+                .socialType(SocialType.KAKAO)
+                .socialId("12345")
+                .nickname("김아무")
+                .createdAt(LocalDateTime.now())
+                .account(accountInfo)
+                .build();
+    }
+
+    private Wish createWish(User user) {
+        return Wish.builder()
+                .wisher(user)
+                .presentImageUrl("image-url")
+                .title("소원 제목")
+                .hint("소원 힌트")
+                .initial("ㅅㅇ ㅈㅁ")
+                .presentPrice(50000)
+                .startAt(Util.convertToDate(getLocalDateTime(0)))
+                .endAt(Util.convertToDate(getLocalDateTime(7)))
+                .build();
+    }
+}


### PR DESCRIPTION
## ✨ 관련 이슈
closed #139 

## ✨ 변경 사항 및 이유
- 캐시를 적용하였습니다.
<img width="461" alt="image" src="https://github.com/Make-A-Wish-Sopt/Make-A-Wish-Server/assets/58364342/222270a0-89a9-441c-9c60-46b2f800681e"> <br/>    
* 선물들을 확인할 때 모인 케이크 상세 확인을 여러 번 호출하며 선물을 확인한다고 생각하여 이 부분을 로컬 캐시 중 카페인 캐시로 적용했습니다. 
* 또한 이 정보는 이미 소원이 끝난 후에 얻는 것이기에 값의 변동이 없어 캐시로 설정해도 괜찮다고 생각했습니다. 

<br/>

<img width="361" alt="image" src="https://github.com/Make-A-Wish-Sopt/Make-A-Wish-Server/assets/58364342/7aa7b9e0-3ed6-41c1-8e52-81f756843b3e"> <br/>
- 캐시를 적용하여 테스트를 통해 시간을 확인하였습니다.


## ✨ PR Point
- 선물이 많은 경우를 대비해 캐시 시간을 넉넉하게 30분을 잡았습니다. 너무 긴 것 같으면 더 짧게 줄이겠습니다! 

