### PR TITLE
[ADD] 휴대전화 및 계좌번호 암호화 로직 설정

### DIFF
--- a/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
+++ b/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
@@ -35,20 +35,31 @@ public class KeyEncrypt {
             this.secretKeySpec = new SecretKeySpec(secretKey.getBytes(ENCODING_TYPE), ALGORITHM);
             this.ivParameterSpec = new IvParameterSpec(iv.getBytes());
             this.cipher = Cipher.getInstance(TRANSFORMATION);
-            this.cipher.init(Cipher.ENCRYPT_MODE, this.secretKeySpec, this.ivParameterSpec);
-        } catch (InvalidAlgorithmParameterException | InvalidKeyException | NoSuchPaddingException | NoSuchAlgorithmException e ){
+        } catch (NoSuchPaddingException | NoSuchAlgorithmException e) {
             log.error("error: Initializing KeyEncrypt ", e);
             throw new RuntimeException("error: Initializing KeyEncrypt ", e);
         }
     }
 
-    public String encrypt(String plainText) throws IllegalBlockSizeException, BadPaddingException {
-        byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(ENCODING_TYPE));
-        return Base64.getEncoder().encodeToString(encryptedBytes);
+    public String encrypt(String plainText) {
+        try {
+            this.cipher.init(Cipher.ENCRYPT_MODE, this.secretKeySpec, this.ivParameterSpec);
+            byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(ENCODING_TYPE));
+            return Base64.getEncoder().encodeToString(encryptedBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException | InvalidAlgorithmParameterException |
+                 InvalidKeyException e) {
+            throw new RuntimeException("error: Encrypting text ", e);
+        }
     }
 
-    public String decrypt(String encryptedText) throws IllegalBlockSizeException, BadPaddingException {
-        byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
-        return new String(decryptedBytes, ENCODING_TYPE);
+    public String decrypt(String encryptedText) {
+        try {
+            this.cipher.init(Cipher.DECRYPT_MODE, this.secretKeySpec, this.ivParameterSpec);
+            byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
+            return new String(decryptedBytes, ENCODING_TYPE);
+        } catch (IllegalBlockSizeException | BadPaddingException | InvalidAlgorithmParameterException |
+                 InvalidKeyException e) {
+            throw new RuntimeException("error: Decrypting text ", e);
+        }
     }
 }

--- a/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
+++ b/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
@@ -25,9 +25,7 @@ public class KeyEncrypt {
     private static final Charset ENCODING_TYPE = StandardCharsets.UTF_8;
     private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
     private final SecretKeySpec secretKeySpec;
-
     private final IvParameterSpec ivParameterSpec;
-
     private final Cipher cipher;
 
     public KeyEncrypt(@Value("${crypto.secret-key}") String secretKey, @Value("${crypto.iv}") String iv) {

--- a/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
+++ b/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
@@ -1,0 +1,42 @@
+package com.sopterm.makeawish.config.crypto;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+
+@Slf4j
+@Component
+public class KeyEncrypt {
+    private static final String ALGORITHM = "AES";
+    private static final Charset ENCODING_TYPE = StandardCharsets.UTF_8;
+    private static final String TRANSFORMATION = "AES/ECB/PKCS5Padding";
+    private final String secretKey = "tjqjsecretkey0306!";
+
+
+    public String encrpyt(String plainText) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(ENCODING_TYPE), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+        byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(ENCODING_TYPE));
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    public String decrypt(String encryptedText) throws NoSuchPaddingException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, InvalidKeyException {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), ALGORITHM);
+        Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+        byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
+        return new String(decryptedBytes, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
+++ b/src/main/java/com/sopterm/makeawish/config/crypto/KeyEncrypt.java
@@ -1,15 +1,18 @@
 package com.sopterm.makeawish.config.crypto;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -20,23 +23,31 @@ import java.util.Base64;
 public class KeyEncrypt {
     private static final String ALGORITHM = "AES";
     private static final Charset ENCODING_TYPE = StandardCharsets.UTF_8;
-    private static final String TRANSFORMATION = "AES/ECB/PKCS5Padding";
-    private final String secretKey = "tjqjsecretkey0306!";
+    private static final String TRANSFORMATION = "AES/CBC/PKCS5Padding";
 
+    @Value("${crypto.secret-key}")
+    private String secretKey;
 
-    public String encrpyt(String plainText) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
+    @Value("${crypto.iv}")
+    private String iv;
+
+    public String encrypt(String plainText) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException, InvalidAlgorithmParameterException {
         SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(ENCODING_TYPE), ALGORITHM);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv.getBytes());
         Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec, ivParameterSpec);
+
         byte[] encryptedBytes = cipher.doFinal(plainText.getBytes(ENCODING_TYPE));
         return Base64.getEncoder().encodeToString(encryptedBytes);
     }
 
-    public String decrypt(String encryptedText) throws NoSuchPaddingException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, InvalidKeyException {
+    public String decrypt(String encryptedText) throws NoSuchPaddingException, NoSuchAlgorithmException, IllegalBlockSizeException, BadPaddingException, InvalidKeyException, InvalidAlgorithmParameterException {
         SecretKeySpec secretKeySpec = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), ALGORITHM);
         Cipher cipher = Cipher.getInstance(TRANSFORMATION);
-        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv.getBytes());
+        cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, ivParameterSpec);
+
         byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
-        return new String(decryptedBytes, StandardCharsets.UTF_8);
+        return new String(decryptedBytes, ENCODING_TYPE);
     }
 }

--- a/src/test/java/com/sopterm/makeawish/config/crypto/KeyEncryptTest.java
+++ b/src/test/java/com/sopterm/makeawish/config/crypto/KeyEncryptTest.java
@@ -1,0 +1,23 @@
+package com.sopterm.makeawish.config.crypto;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class KeyEncryptTest {
+    @Autowired
+    KeyEncrypt keyEncryptService;
+
+    @Test
+    @DisplayName("암호화/복호화 성공 테스트")
+    void 암호화_복호화_성공() throws Exception {
+        String plainAccountText = "1234567890";
+
+        String encryptedText = keyEncryptService.encrypt(plainAccountText);
+
+        Assertions.assertEquals(plainAccountText, keyEncryptService.decrypt(encryptedText));
+    }
+}

--- a/src/test/java/com/sopterm/makeawish/config/crypto/KeyEncryptTest.java
+++ b/src/test/java/com/sopterm/makeawish/config/crypto/KeyEncryptTest.java
@@ -3,10 +3,15 @@ package com.sopterm.makeawish.config.crypto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @SpringBootTest
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
 class KeyEncryptTest {
     @Autowired
     KeyEncrypt keyEncryptService;
@@ -17,7 +22,8 @@ class KeyEncryptTest {
         String plainAccountText = "1234567890";
 
         String encryptedText = keyEncryptService.encrypt(plainAccountText);
+        String decryptedText = keyEncryptService.decrypt(encryptedText);
 
-        Assertions.assertEquals(plainAccountText, keyEncryptService.decrypt(encryptedText));
+        Assertions.assertEquals(plainAccountText, decryptedText);
     }
 }


### PR DESCRIPTION
## ✨ 관련 이슈
closed #141 

## ✨ 변경 사항 및 이유
- 암호화가 필요하다 생각한 이유는 개인정보를 디비에 직접적으로 노출하는 건 안전하지 않다 생각해서 암호화를 작업하였습니다.   
- 사용한 알고리즘은 AES-256입니다.
- 현재 계좌번호, 휴대전화 입력 시 암호화/복호화를 진행하고 있지 않은 이유는 계좌번호 관련 기획이 정해지고 난 뒤에 설정하겠습니다.

## ✨ PR Point
- 아주 간단한 테스트를 만들었습니다.
- `application-dev.yml`과 `application-test.yml`에 사용되는 키값들을 추가하였습니다.
